### PR TITLE
fix: format site config

### DIFF
--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -74,7 +74,7 @@ export const siteConfig: SiteConfig = {
         { label: "root -at- cubeyond -dot- net" },
         {
           label: "PGP Encryption Key",
-          href: "/key.asc",
+          href: "/key.asc"
         },
         {
           label: "github@plt",


### PR DESCRIPTION
## Summary

- remove the Biome-rejected trailing comma in `src/config/site.ts`
- restore CI after the redacted phile cleanup commit

## Verification

- pnpm exec biome ci .
- pnpm check
- pnpm build