### PR TITLE
New ansi escape sequences

### DIFF
--- a/src/config/cves.ts
+++ b/src/config/cves.ts
@@ -34,5 +34,15 @@ export const cveRecords: CveRecord[] = [
     id: "CVE-2026-56117",
     title: "dhcpcd Heap Use-After-Free via Control Socket Handling",
     date: "2026-06-23"
+  },
+  {
+    id: "CVE-2026-58458",
+    title: "Don't Starve Together Public Lobby world_gen_data Client DoS",
+    date: "2026-06-27"
+  },
+  {
+    id: "CVE-2026-58459",
+    title: "GPSD gpsprof gnuplot Command Injection via GPS Metadata",
+    date: "2026-06-27"
   }
 ];

--- a/src/content/philes/volume-3/experiments/ansi-ink-phile.phile
+++ b/src/content/philes/volume-3/experiments/ansi-ink-phile.phile
@@ -76,7 +76,7 @@ Escaping is local:
     #[c|escape a pipe: \|]
     #[c|escape a close bracket: \]]
 
-Additional text sequencies can be used:
+Additional text styles can be used:
 
     #[bold|bold] #[italic|italic] #[underline|underline] #[strike|strike]
 
@@ -85,7 +85,11 @@ They can even be combined using a semicolon:
     source: An \#[underline;r|underlined red] text
     render: An #[underline;r|underlined red] text
 
-Bold and italic are not render because the font is missing those glyphs.
+    #[underline;strike|underlined and struck through]
+
+Bold and italic syntax is accepted, but the styles are not visible because the
+current font bundle only contains a regular face and synthetic styles are
+disabled.
 
 [ 2. Palette ]─────────────────────────────────────────────────────────────//───
 

--- a/src/content/philes/volume-3/experiments/ansi-ink-phile.phile
+++ b/src/content/philes/volume-3/experiments/ansi-ink-phile.phile
@@ -76,6 +76,17 @@ Escaping is local:
     #[c|escape a pipe: \|]
     #[c|escape a close bracket: \]]
 
+Additional text sequencies can be used:
+
+    #[bold|bold] #[italic|italic] #[underline|underline] #[strike|strike]
+
+They can even be combined using a semicolon:
+
+    source: An \#[underline;r|underlined red] text
+    render: An #[underline;r|underlined red] text
+
+Bold and italic are not render because the font is missing those glyphs.
+
 [ 2. Palette ]─────────────────────────────────────────────────────────────//───
 
 The palette follows Tokyo Night terminal colors [1], but remains ANSI-shaped,

--- a/src/modules/textmode/ansi/render.ts
+++ b/src/modules/textmode/ansi/render.ts
@@ -52,7 +52,11 @@ const ansiRoles = new Map<string, string>([
   ["bright-cyan", "bright-cyan"],
   ["W", "bright-white"],
   ["br-white", "bright-white"],
-  ["bright-white", "bright-white"]
+  ["bright-white", "bright-white"],
+  ["bold", "bold"],
+  ["italic", "italic"],
+  ["underline", "underline"],
+  ["strike", "strike"],
 ]);
 
 const inkBlockPattern = /^\s*--\[ ink \]--\s*$/;
@@ -225,15 +229,22 @@ function parseMarker(input: string, start: number): { role: string; text: string
     return undefined;
   }
 
-  const alias = input.slice(start + 2, pipe).trim();
-  const role = ansiRoles.get(alias);
+  const aliases = input.slice(start + 2, pipe).trim().split(";");
+  const roles: string[] = [];
 
-  if (!role) {
-    throw new Error(`Unknown ANSI role "${alias}".`);
+  for (const alias of aliases) {
+    const trimmedAlias = alias.trim();
+    const role = ansiRoles.get(trimmedAlias);
+
+    if (!role) {
+      throw new Error(`Unknown ANSI role "${trimmedAlias}".`);
+    }
+
+    roles.push(role);
   }
 
   return {
-    role,
+    role: roles.join(" "), // Space-separated roles
     text: unescapeAnsiText(input.slice(pipe + 1, close)),
     end: close + 1
   };
@@ -285,9 +296,14 @@ function appendChunk(chunks: RenderChunk[], chunk: RenderChunk): void {
 
 function renderChunks(chunks: RenderChunk[]): string {
   return chunks
-    .map((chunk) =>
-      chunk.role ? `<span class="ansi ansi-${chunk.role}">${textHtml(chunk.text)}</span>` : textHtml(chunk.text)
-    )
+    .map((chunk) => {
+      if (!chunk.role) {
+        return textHtml(chunk.text);
+      }
+
+      const classes = ["ansi", ...chunk.role.split(" ").map(r => `ansi-${r}`)].join(" ");
+      return `<span class="${classes}">${textHtml(chunk.text)}</span>`;
+    })
     .join("");
 }
 

--- a/src/modules/textmode/ansi/render.ts
+++ b/src/modules/textmode/ansi/render.ts
@@ -56,7 +56,7 @@ const ansiRoles = new Map<string, string>([
   ["bold", "bold"],
   ["italic", "italic"],
   ["underline", "underline"],
-  ["strike", "strike"],
+  ["strike", "strike"]
 ]);
 
 const inkBlockPattern = /^\s*--\[ ink \]--\s*$/;
@@ -229,7 +229,10 @@ function parseMarker(input: string, start: number): { role: string; text: string
     return undefined;
   }
 
-  const aliases = input.slice(start + 2, pipe).trim().split(";");
+  const aliases = input
+    .slice(start + 2, pipe)
+    .trim()
+    .split(";");
   const roles: string[] = [];
 
   for (const alias of aliases) {
@@ -301,7 +304,7 @@ function renderChunks(chunks: RenderChunk[]): string {
         return textHtml(chunk.text);
       }
 
-      const classes = ["ansi", ...chunk.role.split(" ").map(r => `ansi-${r}`)].join(" ");
+      const classes = ["ansi", ...chunk.role.split(" ").map((r) => `ansi-${r}`)].join(" ");
       return `<span class="${classes}">${textHtml(chunk.text)}</span>`;
     })
     .join("");

--- a/src/modules/textmode/ansi/render.ts
+++ b/src/modules/textmode/ansi/render.ts
@@ -4,12 +4,18 @@ import { normalizeText } from "../core/text";
 
 type AnsiToken = {
   text: string;
-  role?: string;
+  roles?: string[];
 };
 
 type RenderChunk = {
   text: string;
-  role?: string;
+  roles?: string[];
+};
+
+type ParsedMarker = {
+  roles: string[];
+  text: string;
+  end: number;
 };
 
 const ansiRoles = new Map<string, string>([
@@ -124,7 +130,7 @@ function renderPlainAnsiLines(input: string, width: number): string[] {
         flushLine();
       }
 
-      appendChunk(lineChunks, { text: char, role: token.role });
+      appendChunk(lineChunks, { text: char, roles: token.roles });
       lineWidth += charWidth;
     }
   }
@@ -171,7 +177,7 @@ function renderInkTextLine(text: string, mask: string, width: number): string[] 
 
   for (const char of text) {
     const role = roleForMask(mask[index]);
-    appendChunk(chunks, { text: char, role });
+    appendChunk(chunks, { text: char, roles: role ? [role] : undefined });
     index += 1;
   }
 
@@ -195,7 +201,7 @@ function parseInlineAnsi(input: string): AnsiToken[] {
 
       if (parsed) {
         flushPlain();
-        tokens.push({ text: parsed.text, role: parsed.role });
+        tokens.push({ text: parsed.text, roles: parsed.roles });
         cursor = parsed.end;
         continue;
       }
@@ -216,7 +222,7 @@ function parseInlineAnsi(input: string): AnsiToken[] {
   }
 }
 
-function parseMarker(input: string, start: number): { role: string; text: string; end: number } | undefined {
+function parseMarker(input: string, start: number): ParsedMarker | undefined {
   const pipe = findUnescaped(input, "|", start + 2);
 
   if (pipe === -1) {
@@ -247,7 +253,7 @@ function parseMarker(input: string, start: number): { role: string; text: string
   }
 
   return {
-    role: roles.join(" "), // Space-separated roles
+    roles,
     text: unescapeAnsiText(input.slice(pipe + 1, close)),
     end: close + 1
   };
@@ -289,7 +295,7 @@ function roleForMask(char: string | undefined): string | undefined {
 function appendChunk(chunks: RenderChunk[], chunk: RenderChunk): void {
   const previous = chunks[chunks.length - 1];
 
-  if (previous && previous.role === chunk.role) {
+  if (previous && sameRoles(previous.roles, chunk.roles)) {
     previous.text += chunk.text;
     return;
   }
@@ -297,14 +303,26 @@ function appendChunk(chunks: RenderChunk[], chunk: RenderChunk): void {
   chunks.push(chunk);
 }
 
+function sameRoles(left: string[] | undefined, right: string[] | undefined): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (!left || !right || left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((role, index) => role === right[index]);
+}
+
 function renderChunks(chunks: RenderChunk[]): string {
   return chunks
     .map((chunk) => {
-      if (!chunk.role) {
+      if (!chunk.roles) {
         return textHtml(chunk.text);
       }
 
-      const classes = ["ansi", ...chunk.role.split(" ").map((r) => `ansi-${r}`)].join(" ");
+      const classes = ["ansi", ...chunk.roles.map((role) => `ansi-${role}`)].join(" ");
       return `<span class="${classes}">${textHtml(chunk.text)}</span>`;
     })
     .join("");
@@ -323,7 +341,7 @@ function renderWrappedChunks(chunks: RenderChunk[], width: number): string[] {
         flushLine();
       }
 
-      appendChunk(lineChunks, { text: char, role: chunk.role });
+      appendChunk(lineChunks, { text: char, roles: chunk.roles });
       lineWidth += charWidth;
     }
   }

--- a/src/styles/modules/ansi.css
+++ b/src/styles/modules/ansi.css
@@ -65,3 +65,19 @@
 .ansi-bright-white {
   color: var(--ansi-bright-white, #ffffff);
 }
+
+.ansi-bold {
+  font-weight: bold;
+}
+
+.ansi-italic {
+  font-style: italic;
+}
+
+.ansi-underline {
+  text-decoration: underline;
+}
+
+.ansi-strike {
+  text-decoration: line-through;
+}

--- a/src/styles/modules/ansi.css
+++ b/src/styles/modules/ansi.css
@@ -75,9 +75,13 @@
 }
 
 .ansi-underline {
-  text-decoration: underline;
+  text-decoration-line: underline;
 }
 
 .ansi-strike {
-  text-decoration: line-through;
+  text-decoration-line: line-through;
+}
+
+.ansi-underline.ansi-strike {
+  text-decoration-line: underline line-through;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Classical ANSI escape codes allow the use of **bold**, _italics_, <ins>underlined</ins> and ~~striked-through~~ text. This PR adds such options to the ANSI Ink notation layer.

Font styles can be combined with a semicolon following real ANSI escape sequences. For example: `#[underline;r|sample text]` would produced red underlined text.

The `--[ ink ]--` notation is not supported for different font styles.

The included `gohu.woff` font does not include italics nor bold glyphs, so they won't be rendered.

A deprecation warning for the future version of TypeScript 7.0 is fixed.

## Scope

- [x] User-facing behavior
- [x] Content
- [ ] Documentation
- [ ] Tooling or automation
- [ ] Build, CI, or deployment
- [ ] Performance or maintenance

## Verification

Run without errors the following commands:

```text
pnpm check
pnpm build
```

## Notes

It would be nice to support bold and italic fonts, a subset of them, like it is done now.
