### PR TITLE
fix(textmode): align page content to device pixels

### DIFF
--- a/src/modules/textmode/alignment/install.ts
+++ b/src/modules/textmode/alignment/install.ts
@@ -1,0 +1,56 @@
+const alignedSelector = ".screen > .home-shell, .screen > .textmode-wrap";
+
+export function installTextmodeAlignment(mobileFitBreakpoint: number): void {
+  const elements = [...document.querySelectorAll<HTMLElement>(alignedSelector)];
+  if (elements.length === 0) {
+    return;
+  }
+
+  const mobile = window.matchMedia(`(max-width: ${mobileFitBreakpoint}px)`);
+  let animationFrame = 0;
+
+  const align = () => {
+    // Measure the original layout each time so resize corrections cannot accumulate.
+    for (const element of elements) {
+      element.style.removeProperty("--pixel-align-x");
+      element.style.removeProperty("--pixel-align-y");
+    }
+
+    if (mobile.matches) {
+      return;
+    }
+
+    const ratio = window.devicePixelRatio;
+    const offsets = elements.map((element) => {
+      const { left, top } = element.getBoundingClientRect();
+      return {
+        x: Math.round(left * ratio) / ratio - left,
+        y: Math.round(top * ratio) / ratio - top
+      };
+    });
+
+    elements.forEach((element, index) => {
+      element.style.setProperty("--pixel-align-x", `${offsets[index].x}px`);
+      element.style.setProperty("--pixel-align-y", `${offsets[index].y}px`);
+    });
+  };
+
+  const scheduleAlignment = () => {
+    if (animationFrame !== 0) {
+      return;
+    }
+    animationFrame = window.requestAnimationFrame(() => {
+      animationFrame = 0;
+      align();
+    });
+  };
+
+  const observer = new ResizeObserver(scheduleAlignment);
+  observer.observe(document.documentElement);
+  for (const element of elements) {
+    observer.observe(element);
+  }
+  window.addEventListener("resize", scheduleAlignment, { passive: true });
+  void document.fonts.ready.then(scheduleAlignment);
+  scheduleAlignment();
+}

--- a/src/modules/textmode/bootstrap/install.ts
+++ b/src/modules/textmode/bootstrap/install.ts
@@ -1,3 +1,5 @@
+import { installTextmodeAlignment } from "../alignment/install";
+
 type BootstrapOptions = {
   mobileFitBreakpoint: number;
   particlesEnabled: boolean;
@@ -10,6 +12,7 @@ export function installTextmodeBootstrap(options = readOptions()): void {
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
   installMobileFit(options.mobileFitBreakpoint);
+  installTextmodeAlignment(options.mobileFitBreakpoint);
 
   if (options.particlesEnabled && !reducedMotion) {
     window.addEventListener(

--- a/src/styles/modules/base.css
+++ b/src/styles/modules/base.css
@@ -56,3 +56,10 @@ a:focus-visible {
   max-width: 100vw;
   overflow-x: auto;
 }
+
+.screen > .home-shell,
+.screen > .textmode-wrap {
+  position: relative;
+  left: var(--pixel-align-x, 0px);
+  top: var(--pixel-align-y, 0px);
+}


### PR DESCRIPTION
## Summary

Centered textmode content can land between physical pixels, blurring fonts and borders. Automatically align the home, 404, volume and article containers on both axes after fonts load and when the layout resizes. Batch layout measurements and reset the offsets when mobile fitting takes over.

## Scope

- [x] User-facing behavior
- [ ] Content
- [ ] Documentation
- [ ] Tooling or automation
- [ ] Build, CI, or deployment
- [x] Performance or maintenance

## Verification

- Reproduced the alignment failure on the unchanged branch before applying the fix.
- Firefox and Chromium: home, 404, missing route, volume and article pages at DPR 1, 1.25 and 2, with odd/even viewport sizes, repeated resizing and mobile transitions.
- `pnpm lint`
- `pnpm build` (includes Astro and Biome checks)

## Notes

The fix loads through the existing site bootstrap and requires no configuration.
