### PR TITLE
fix(checks): parse Astro scripts for module boundary validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
+    "@astrojs/compiler-rs": "^0.4.0",
     "@biomejs/biome": "^2.5.12",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.10
         version: 0.9.10(@typescript/typescript6@6.0.2)(prettier-plugin-astro@0.14.1)(prettier@3.9.6)
+      '@astrojs/compiler-rs':
+        specifier: ^0.4.0
+        version: 0.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
       '@biomejs/biome':
         specifier: ^2.5.12
         version: 2.5.12

--- a/scripts/checks/boundaries.mjs
+++ b/scripts/checks/boundaries.mjs
@@ -2,6 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { isBuiltin } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { parse } from "@astrojs/compiler-rs";
 import ts from "typescript";
 
 const root = fileURLToPath(new URL("../../", import.meta.url));
@@ -14,13 +15,7 @@ const errors = [];
 for (const file of files) {
   const text = await readFile(file, "utf8");
   const scripts = file.endsWith(".astro")
-    ? [
-        { source: /^---\r?\n([\s\S]*?)\r?\n---/.exec(text)?.[1] ?? "", browser: false },
-        ...[...text.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/g)].map((match) => ({
-          source: match[1],
-          browser: true
-        }))
-      ]
+    ? astroScripts(text, file)
     : [{ source: text, browser: /(?:\/client(?:\/|\.ts)|\/glitch\/)/.test(file) }];
   const dependencies = [];
   for (const { source, browser } of scripts) {
@@ -77,6 +72,40 @@ async function walk(directory) {
     })
   );
   return files.flat();
+}
+
+function astroScripts(source, file) {
+  const { ast, diagnostics } = parse(source);
+  const failures = diagnostics.filter((diagnostic) => diagnostic.severity === "error");
+  if (failures.length > 0) {
+    errors.push(`${relative(file)}: Unable to parse Astro: ${failures.map((failure) => failure.text).join("; ")}`);
+    return [];
+  }
+  const frontmatter = ast.frontmatter.program;
+  const scripts = [{ source: source.slice(frontmatter.start, frontmatter.end), browser: false }];
+
+  function visit(node) {
+    if (!node || typeof node !== "object") return;
+    if (
+      node.type === "JSXElement" &&
+      node.openingElement.name.type === "JSXIdentifier" &&
+      node.openingElement.name.name.toLowerCase() === "script"
+    ) {
+      if (node.closingElement) {
+        scripts.push({
+          source: source.slice(node.openingElement.end, node.closingElement.start),
+          browser: true
+        });
+      }
+      return;
+    }
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value)) value.forEach(visit);
+      else visit(value);
+    }
+  }
+  visit(ast.body);
+  return scripts;
 }
 
 function imports(source) {

--- a/tests/checks/boundaries.test.mjs
+++ b/tests/checks/boundaries.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+async function checkAstro(source) {
+  const root = await mkdtemp(path.join(tmpdir(), "entropic-boundaries-"));
+  try {
+    await mkdir(path.join(root, "scripts/checks"), { recursive: true });
+    await mkdir(path.join(root, "src"));
+    await copyFile(
+      path.join(projectRoot, "scripts/checks/boundaries.mjs"),
+      path.join(root, "scripts/checks/boundaries.mjs")
+    );
+    await symlink(path.join(projectRoot, "node_modules"), path.join(root, "node_modules"), "dir");
+    await writeFile(path.join(root, "entropic.config.ts"), "export default {};\n");
+    await writeFile(path.join(root, "src/Page.astro"), source);
+    const result = spawnSync(process.execPath, ["scripts/checks/boundaries.mjs"], {
+      cwd: root,
+      encoding: "utf8",
+      timeout: 10_000
+    });
+    assert.ifError(result.error);
+    return result;
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test("browser scripts cannot import Node builtins regardless of tag casing", async () => {
+  for (const tag of ["script", "SCRIPT", "ScRiPt"]) {
+    const result = await checkAstro(`<${tag}>\nimport "node:fs";\n</${tag}>`);
+    assert.equal(result.status, 1, `${tag}: ${result.stdout}${result.stderr}`);
+    assert.match(result.stderr, /browser dependency reaches node:fs/);
+  }
+});
+
+test("script extraction respects tag syntax, nesting, and Unicode offsets", async () => {
+  for (const source of [
+    '<script>import "node:fs";</script >',
+    '<script>import "node:fs";</script data-note="ignored">',
+    '<script data-note="a > b">import "node:fs";</script>',
+    '<p>幽灵 👻</p><script>import "node:fs";</script>',
+    '<main>{true && <section><script>import "node:fs";</script></section>}</main>',
+    '<script>console.log("safe");</script><script>import "node:fs";</script>'
+  ]) {
+    const result = await checkAstro(source);
+    assert.equal(result.status, 1, `${source}: ${result.stdout}${result.stderr}`);
+    assert.match(result.stderr, /browser dependency reaches node:fs/);
+  }
+});
+
+test("server imports and script-like text are not browser dependencies", async () => {
+  for (const source of [
+    '---\nimport "node:fs";\n---\n<div />',
+    '<!-- <script>import "node:fs";</script> -->',
+    '---\nconst example = `<script>import "node:fs";</script>`;\n---\n<div />',
+    "<p>{'<script>import \"node:fs\";</script>'}</p>",
+    '<script>import type { Stats } from "node:fs";</script>'
+  ]) {
+    const result = await checkAstro(source);
+    assert.equal(result.status, 0, `${source}: ${result.stdout}${result.stderr}`);
+    assert.equal(result.stderr, "");
+  }
+});
+
+test("invalid Astro cannot silently pass the boundary check", async () => {
+  const result = await checkAstro("<script>const = ;</script>");
+  assert.equal(result.status, 1, result.stdout);
+  assert.match(result.stderr, /src\/Page\.astro: Unable to parse Astro: Unexpected token/);
+});


### PR DESCRIPTION
The module boundary checker could miss browser imports in uppercase script
tags or tags with closing whitespace, and falsely flag script-like text in
comments and frontmatter strings. It now uses Astro's Rust parser to locate
script bodies and rejects parsing errors instead of reporting success.

Removes the HTML regexp identified by [CodeQL alert #1](https://github.com/CuB3y0nd/entropic/security/code-scanning/1).
This checker runs during development and CI; it is not an HTML sanitizer in
the rendered site.

Validation: all 56 regression tests pass, including four new CLI regression
tests that fail before the fix. `pnpm build` passes and generates 67 pages.
