### PR TITLE
feat(philes): add shareable passage links

### DIFF
--- a/README
+++ b/README
@@ -21,8 +21,12 @@ inherits the banner from `src/config/defaults.ts` unless overridden; WKD and
 the CVE page are explicitly enabled.
 Set `cves.enabled: false` to omit the CVE page, its homepage links, and its sitemap
 entry; the records can remain in `cves.records` for later use.
-Article number and byte inspection is enabled by default.
-Set `philes.inspect: false` to disable its selection menu across articles.
+Article inspection and fragment links are enabled by default. Select article
+text to inspect a value or prepare a link to that passage, then copy with your
+browser's native Copy action. Fragment links locate the quoted text and briefly
+highlight it; repeated passages need enough context to identify one match.
+Set `philes.inspect: false` or `philes.fragmentLinks: false` to disable either
+tool. Disabling fragment links also disables incoming passage navigation.
 
 The file is a plain TypeScript object with `as const satisfies EntropicConfig`.
 Your editor provides field descriptions and completion, including artwork

--- a/entropic.config.ts
+++ b/entropic.config.ts
@@ -107,7 +107,9 @@ export default {
   // Article features and reading behavior.
   philes: {
     // Inspect selected numbers and bytes. Defaults to true; false disables it.
-    inspect: true
+    inspect: true,
+    // Share and open links to selected article text. Defaults to true.
+    fragmentLinks: true
   },
 
   // 88x31 buttons. Each item has label, imageSrc, and exactly one action:

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -17,7 +17,10 @@ export function resolveConfig(input: EntropicConfig) {
       asciiArt: input.home?.asciiArt ?? defaultHomeAsciiArt,
       sections: input.home?.sections ?? []
     },
-    philes: { inspect: input.philes?.inspect ?? true },
+    philes: {
+      inspect: input.philes?.inspect ?? true,
+      fragmentLinks: input.philes?.fragmentLinks ?? true
+    },
     volumes: input.volumes ?? {},
     cves: { enabled: input.cves?.enabled ?? false, records: input.cves?.records ?? [] },
     buttons: {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -95,6 +95,8 @@ export type EntropicConfig = {
   readonly philes?: {
     /** Selection-based number and byte inspection in articles. Defaults to true. */
     readonly inspect?: boolean;
+    /** Create and open links to selected article text. Defaults to true. */
+    readonly fragmentLinks?: boolean;
   };
   /** Keys are non-negative volume numbers, not titles or routes. */
   readonly volumes?: Readonly<Record<number, Partial<VolumeConfig>>>;

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -40,7 +40,9 @@ export function validateConfig(config: ResolvedConfig): void {
     integer(socialImage.width, "site.socialImage.width", 1);
     integer(socialImage.height, "site.socialImage.height", 1);
   }
-  if (typeof config.philes.inspect !== "boolean") fail("philes.inspect", "Use true or false.");
+  for (const [key, value] of Object.entries(config.philes)) {
+    if (typeof value !== "boolean") fail(`philes.${key}`, "Use true or false.");
+  }
   singleLinePrefix(config.home.sectionPrefix, "home.sectionPrefix");
   singleLinePrefix(config.home.itemPrefix, "home.itemPrefix");
   nonEmpty(config.home.asciiArt, "home.asciiArt");

--- a/src/features/philes/citations/client.ts
+++ b/src/features/philes/citations/client.ts
@@ -1,0 +1,153 @@
+import type { SelectionTool } from "../selection/types";
+import { quoteText } from "./limits";
+
+type CitationDocument = ReturnType<typeof import("./document").createCitationDocument>;
+type CitationMarker = ReturnType<typeof import("./marker").createCitationMarker>;
+
+export function createCitationTool(root: HTMLElement): SelectionTool | null {
+  const trigger = root.querySelector<HTMLButtonElement>("[data-fragment-trigger]");
+  const panel = root.querySelector<HTMLElement>("[data-fragment-panel]");
+  const value = panel?.querySelector<HTMLTextAreaElement>("[data-fragment-url]");
+  const field = panel?.querySelector<HTMLElement>("[data-fragment-field]");
+  const size = field?.querySelector<HTMLElement>("[data-fragment-url-size]");
+  const message = panel?.querySelector<HTMLElement>("[data-fragment-message]");
+  const article = document.querySelector<HTMLElement>(".phile-wrap");
+  const status = document.querySelector<HTMLElement>("[data-fragment-status]");
+  if (!trigger || !panel || !value || !field || !size || !message || !article || !status) return null;
+  let index: Promise<CitationDocument> | null = null;
+  const load = (): Promise<CitationDocument> => {
+    index ??= import("./document")
+      .then(({ createCitationDocument }) => createCitationDocument(article))
+      .catch((error) => {
+        index = null;
+        throw error;
+      });
+    return index;
+  };
+  let navigation = 0;
+  let fadeTimer = 0;
+  let clearTimer = 0;
+  let observer: ResizeObserver | null = null;
+  let marker: CitationMarker | null = null;
+  let navigationEvents: AbortController | null = null;
+  const clear = (): void => {
+    clearTimeout(fadeTimer);
+    clearTimeout(clearTimer);
+    navigationEvents?.abort();
+    navigationEvents = null;
+    observer?.disconnect();
+    observer = null;
+    marker?.remove();
+    marker = null;
+    CSS.highlights?.delete("entropic-fragment");
+    article.classList.remove("fragment-target");
+    status.hidden = true;
+  };
+  const interrupt = (): void => {
+    navigation++;
+    clear();
+  };
+  const restore = async (): Promise<void> => {
+    const revision = ++navigation;
+    clear();
+    const fragment = location.hash;
+    if (!fragment.startsWith("#cite=")) return;
+    navigationEvents = new AbortController();
+    for (const type of ["pointerdown", "wheel", "keydown"]) {
+      document.addEventListener(type, interrupt, { passive: true, signal: navigationEvents.signal });
+    }
+    try {
+      const [documentIndex, { createCitationMarker }] = await Promise.all([load(), import("./marker")]);
+      if (revision !== navigation) return;
+      const target = documentIndex.resolve(fragment);
+      if (!target) return;
+      if (target.status !== "found") {
+        status.className = "fragment-notice";
+        status.textContent =
+          target.status === "invalid"
+            ? "This fragment link is invalid."
+            : target.status === "ambiguous"
+              ? "This passage is no longer unique."
+              : "The linked passage has changed.";
+        status.hidden = false;
+        clearTimer = window.setTimeout(clear, 6000);
+        return;
+      }
+      await document.fonts.ready;
+      await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+      if (revision !== navigation) return;
+      marker = createCitationMarker(article, target.range);
+      const position = (): void => {
+        if (revision !== navigation) return;
+        const rect = target.range.getBoundingClientRect();
+        const delta = rect.top - Math.min(innerHeight * 0.28, 200);
+        if (Math.abs(delta) > 1) window.scrollBy(0, delta);
+        marker?.update();
+      };
+      position();
+      if (typeof Highlight === "function" && CSS.highlights) {
+        CSS.highlights.set("entropic-fragment", new Highlight(target.range));
+      }
+      article.classList.add("fragment-target");
+      status.className = "sr-only";
+      status.textContent = `Linked passage: ${target.range.toString().replace(/\s+/gu, " ").trim().slice(0, 160)}`;
+      status.hidden = false;
+      // Keep the target in place while the initial font/grid fit settles. Any
+      // reader input cancels this, so late layout never drags them back.
+      observer = new ResizeObserver(position);
+      observer.observe(article);
+      fadeTimer = window.setTimeout(() => {
+        observer?.disconnect();
+        observer = null;
+        article.classList.remove("fragment-target");
+        clearTimer = window.setTimeout(clear, 600);
+      }, 2600);
+    } catch {
+      if (revision !== navigation) return;
+      clear();
+      status.className = "fragment-notice";
+      status.textContent = "The linked passage could not be opened.";
+      status.hidden = false;
+      clearTimer = window.setTimeout(clear, 6000);
+    }
+  };
+  window.addEventListener("hashchange", () => void restore());
+  void restore();
+
+  value.addEventListener("click", () => value.select());
+  value.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      value.select();
+    }
+  });
+  return {
+    trigger,
+    panel,
+    prepare({ range, text }) {
+      if (!quoteText(text)) return null;
+      return {
+        async show(signal) {
+          try {
+            const documentIndex = await load();
+            if (signal.aborted) return;
+            const fragment = documentIndex.fragment(range);
+            message.hidden = !!fragment;
+            field.hidden = !fragment;
+            message.textContent = "Select a longer passage to make the link unambiguous.";
+            const url = new URL(location.pathname, location.origin);
+            url.hash = fragment ?? "";
+            value.value = fragment ? url.href : "";
+            size.textContent = value.value;
+            value.scrollTop = 0;
+          } catch {
+            if (signal.aborted) return;
+            field.hidden = true;
+            message.hidden = false;
+            message.textContent = "Couldn't prepare this link. Try again.";
+          }
+        }
+      };
+    }
+  };
+}

--- a/src/features/philes/citations/document.ts
+++ b/src/features/philes/citations/document.ts
@@ -1,0 +1,78 @@
+import { ARTICLE_TEXT } from "../selection/types";
+import { type CitationMatch, createQuoteIndex } from "./quotes";
+
+type TextEntry = { node: Text; start: number; end: number };
+
+/** Index only article text; header art, controls and image metadata never enter a citation. */
+export function createCitationDocument(article: HTMLElement) {
+  const entries: TextEntry[] = [];
+  const offsets = new Map<Node, number>();
+  const parts: string[] = [];
+  let length = 0;
+  for (const body of article.querySelectorAll(ARTICLE_TEXT)) {
+    if (parts.length) {
+      parts.push("\n");
+      length++;
+    }
+    const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT);
+    for (let current = walker.nextNode(); current; current = walker.nextNode()) {
+      const node = current as Text;
+      offsets.set(node, length);
+      parts.push(node.data);
+      entries.push({ node, start: length, end: length + node.length });
+      length += node.length;
+    }
+  }
+  const index = createQuoteIndex(parts.join(""));
+
+  const boundary = (container: Node, offset: number): number => {
+    const direct = offsets.get(container);
+    if (direct !== undefined) return direct + offset;
+    // Native selections may end on an element boundary rather than a text node.
+    const point = document.createRange();
+    point.setStart(container, offset);
+    point.collapse(true);
+    let low = 0;
+    let high = entries.length;
+    while (low < high) {
+      const mid = (low + high) >>> 1;
+      const entry = entries[mid];
+      if (entry && point.comparePoint(entry.node, entry.node.length) < 0) low = mid + 1;
+      else high = mid;
+    }
+    const entry = entries[low];
+    return entry ? (point.comparePoint(entry.node, 0) >= 0 ? entry.start : entry.end) : length;
+  };
+  const at = (offset: number): TextEntry | undefined => {
+    let low = 0;
+    let high = entries.length;
+    while (low < high) {
+      const mid = (low + high) >>> 1;
+      const entry = entries[mid];
+      if (entry && entry.end <= offset) low = mid + 1;
+      else high = mid;
+    }
+    return entries[low];
+  };
+
+  return {
+    fragment(range: Range): string | null {
+      if (!range.startContainer.isConnected || !range.endContainer.isConnected) return null;
+      return index.create(
+        boundary(range.startContainer, range.startOffset),
+        boundary(range.endContainer, range.endOffset)
+      );
+    },
+    resolve(fragment: string): { status: "found"; range: Range } | Exclude<CitationMatch, { status: "found" }> | null {
+      const result = index.resolve(fragment);
+      if (result?.status !== "found") return result;
+      const start = at(result.start);
+      const end = at(result.end - 1);
+      if (!start || !end || !start.node.isConnected || !end.node.isConnected) return { status: "missing" };
+      const range = document.createRange();
+      range.setStart(start.node, result.start - start.start);
+      range.setEnd(end.node, result.end - end.start);
+      return { status: "found", range };
+    }
+  };
+}

--- a/src/features/philes/citations/limits.ts
+++ b/src/features/philes/citations/limits.ts
@@ -1,0 +1,12 @@
+export const CITATION_LIMITS = {
+  selection: 16384,
+  quote: 1024,
+  context: 64,
+  fragment: 12000
+} as const;
+
+export function quoteText(source: string): string | null {
+  if (source.length > CITATION_LIMITS.selection) return null;
+  const text = source.replace(/\s+/gu, " ").trim();
+  return text && text.length <= CITATION_LIMITS.quote && text.isWellFormed() ? text : null;
+}

--- a/src/features/philes/citations/marker.ts
+++ b/src/features/philes/citations/marker.ts
@@ -1,0 +1,70 @@
+import { articleBody } from "../selection/types";
+
+type Line = { left: number; right: number; top: number; bottom: number };
+
+/** Paint outside the text nodes so citation offsets and bitmap glyphs stay intact. */
+export function createCitationMarker(article: HTMLElement, range: Range) {
+  const sources: (Range | Element)[] = [];
+  const walker = document.createTreeWalker(article, NodeFilter.SHOW_TEXT);
+  // Article text is immutable. Resolve the quote once; only its geometry changes
+  // as fonts and the responsive grid settle. Bitmap glyphs use their painted box.
+  walker.currentNode = range.startContainer;
+  for (let node: Node | null = walker.currentNode; node; node = walker.nextNode()) {
+    if (articleBody(node)) {
+      const glyph = node.parentElement?.closest(".cjk-bitmap");
+      if (glyph) sources.push(glyph);
+      else {
+        const part = document.createRange();
+        part.setStart(node, node === range.startContainer ? range.startOffset : 0);
+        part.setEnd(node, node === range.endContainer ? range.endOffset : (node.textContent?.length ?? 0));
+        sources.push(part);
+      }
+    }
+    if (node === range.endContainer) break;
+  }
+  const layer = document.createElement("div");
+  layer.className = "fragment-marker";
+  layer.setAttribute("aria-hidden", "true");
+  article.append(layer);
+  const strokes: HTMLSpanElement[] = [];
+
+  return {
+    update(): void {
+      const origin = article.getBoundingClientRect();
+      const zoom = Number.parseFloat(getComputedStyle(article).zoom) || 1;
+      const rects = sources.flatMap((source) => Array.from(source.getClientRects()));
+      rects.sort((a, b) => a.top - b.top || a.left - b.left);
+      const lines: Line[] = [];
+      for (const rect of rects) {
+        if (rect.width <= 0 || rect.height <= 0) continue;
+        const line = lines.at(-1);
+        const overlap = line ? Math.min(line.bottom, rect.bottom) - Math.max(line.top, rect.top) : 0;
+        if (line && overlap > Math.min(line.bottom - line.top, rect.height) / 2) {
+          line.left = Math.min(line.left, rect.left);
+          line.right = Math.max(line.right, rect.right);
+          line.top = Math.min(line.top, rect.top);
+          line.bottom = Math.max(line.bottom, rect.bottom);
+        } else lines.push({ left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom });
+      }
+      // Batch layout reads before writing; ANSI/CJK spans share one stroke per line.
+      for (const [index, line] of lines.entries()) {
+        let stroke = strokes[index];
+        if (!stroke) {
+          stroke = document.createElement("span");
+          stroke.className = "fragment-marker-line";
+          strokes.push(stroke);
+          layer.append(stroke);
+        }
+        // Range rectangles include CSS zoom; positioned children use local units.
+        stroke.style.left = `${(line.left - origin.left) / zoom}px`;
+        stroke.style.top = `${(line.top - origin.top) / zoom}px`;
+        stroke.style.width = `${(line.right - line.left) / zoom}px`;
+        stroke.style.height = `${(line.bottom - line.top) / zoom}px`;
+      }
+      for (const stroke of strokes.splice(lines.length)) stroke.remove();
+    },
+    remove(): void {
+      layer.remove();
+    }
+  };
+}

--- a/src/features/philes/citations/quotes.ts
+++ b/src/features/philes/citations/quotes.ts
@@ -1,0 +1,111 @@
+import { CITATION_LIMITS, quoteText } from "./limits";
+
+type Span = { text: number; source: number; length: number };
+type Quote = { exact: string; prefix: string; suffix: string };
+export type CitationMatch =
+  | { status: "found"; start: number; end: number }
+  | { status: "missing" | "ambiguous" | "invalid" };
+
+const compact = (text: string): string => text.replace(/\s+/gu, "");
+
+function decode(fragment: string): Quote | null {
+  if (fragment.length > CITATION_LIMITS.fragment) return null;
+  try {
+    decodeURIComponent(fragment);
+    const params = new URLSearchParams(fragment.slice(1));
+    if ([...params.keys()].some((key) => !["cite", "prefix", "suffix"].includes(key))) return null;
+    if (["cite", "prefix", "suffix"].some((key) => params.getAll(key).length > 1)) return null;
+    const exact = quoteText(params.get("cite") ?? "");
+    const prefix = params.get("prefix") ?? "";
+    const suffix = params.get("suffix") ?? "";
+    if (!exact || prefix.length > CITATION_LIMITS.context * 2 || suffix.length > CITATION_LIMITS.context * 2)
+      return null;
+    return { exact, prefix, suffix };
+  } catch {
+    return null;
+  }
+}
+
+/** One immutable article index. Whitespace is layout, not an anchor: hard wraps,
+ * indentation and CJK line breaks can change without moving a citation.
+ * Text and context must match exactly otherwise; ambiguous matches never guess. */
+export function createQuoteIndex(source: string): {
+  create: (start: number, end: number) => string | null;
+  resolve: (fragment: string) => CitationMatch | null;
+} {
+  const spans: Span[] = [];
+  const parts: string[] = [];
+  let length = 0;
+  for (const match of source.matchAll(/\S+/gu)) {
+    spans.push({ text: length, source: match.index, length: match[0].length });
+    parts.push(match[0]);
+    length += match[0].length;
+  }
+  const text = parts.join("");
+
+  // Binary search over word runs, rather than a character-sized offset map.
+  const spanAt = (position: number, coordinate: "source" | "text"): Span | undefined => {
+    let low = 0;
+    let high = spans.length;
+    while (low < high) {
+      const mid = (low + high) >>> 1;
+      const span = spans[mid];
+      if (span && span[coordinate] + span.length <= position) low = mid + 1;
+      else high = mid;
+    }
+    return spans[low];
+  };
+  const textOffset = (position: number): number => {
+    const span = spanAt(position, "source");
+    return span ? span.text + Math.max(0, position - span.source) : text.length;
+  };
+  const sourceOffset = (position: number): number => {
+    const span = spanAt(position, "text");
+    return span ? span.source + position - span.text : source.length;
+  };
+  const sourceEnd = (position: number): number => sourceOffset(position - 1) + 1;
+
+  const locate = ({ exact, prefix, suffix }: Quote): CitationMatch => {
+    const before = compact(prefix);
+    const value = compact(exact);
+    const needle = before + value + compact(suffix);
+    const first = text.indexOf(needle);
+    if (first === -1) return { status: "missing" };
+    if (text.indexOf(needle, first + 1) !== -1) return { status: "ambiguous" };
+    const start = first + before.length;
+    return { status: "found", start: sourceOffset(start), end: sourceEnd(start + value.length) };
+  };
+
+  return {
+    create(start, end) {
+      if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end > source.length || end <= start)
+        return null;
+      const exact = quoteText(source.slice(start, end));
+      if (!exact) return null;
+      const from = textOffset(start);
+      const to = textOffset(end);
+      // Add context only when needed. Every candidate is round-tripped against
+      // this document before a link can be offered to the reader.
+      for (const context of [0, 16, 32, CITATION_LIMITS.context]) {
+        const prefix = context ? (quoteText(source.slice(sourceOffset(Math.max(0, from - context)), start)) ?? "") : "";
+        const suffix = context
+          ? (quoteText(source.slice(end, sourceEnd(Math.min(text.length, to + context)))) ?? "")
+          : "";
+        if (prefix.length > CITATION_LIMITS.context * 2 || suffix.length > CITATION_LIMITS.context * 2) continue;
+        const result = locate({ exact, prefix, suffix });
+        if (result.status !== "found" || textOffset(result.start) !== from || textOffset(result.end) !== to) continue;
+        const params = new URLSearchParams({ cite: exact });
+        if (prefix) params.set("prefix", prefix);
+        if (suffix) params.set("suffix", suffix);
+        const fragment = `#${params}`;
+        if (fragment.length <= CITATION_LIMITS.fragment) return fragment;
+      }
+      return null;
+    },
+    resolve(fragment) {
+      if (!fragment.startsWith("#cite=")) return null;
+      const quote = decode(fragment);
+      return quote ? locate(quote) : { status: "invalid" };
+    }
+  };
+}

--- a/src/features/philes/citations/styles.css
+++ b/src/features/philes/citations/styles.css
@@ -1,0 +1,120 @@
+@import "../../../styles/layers.css";
+
+@layer components.features {
+  .fragment-marker {
+    --fragment-ink: #78ff96;
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 0;
+    pointer-events: none;
+    user-select: none;
+  }
+  /* Fade only the small line boxes, never a surface the height of the article. */
+  .fragment-marker-line {
+    position: absolute;
+    opacity: 0;
+    filter: drop-shadow(0 0 3px color-mix(in srgb, var(--fragment-ink) 38%, transparent));
+    transition: opacity 550ms ease-out;
+  }
+  .phile-wrap.fragment-target .fragment-marker-line {
+    opacity: 1;
+  }
+  .fragment-marker-line::before {
+    content: "";
+    position: absolute;
+    inset: 24% -3px -5%;
+    background:
+      linear-gradient(transparent 60%, color-mix(in srgb, var(--fragment-ink) 8%, transparent)),
+      linear-gradient(
+        100deg,
+        color-mix(in srgb, var(--fragment-ink) 22%, transparent),
+        color-mix(in srgb, var(--fragment-ink) 58%, transparent) 4px,
+        color-mix(in srgb, var(--fragment-ink) 50%, transparent) 12%,
+        color-mix(in srgb, var(--fragment-ink) 42%, transparent) 86%,
+        color-mix(in srgb, var(--fragment-ink) 54%, transparent) calc(100% - 3px),
+        color-mix(in srgb, var(--fragment-ink) 20%, transparent)
+      );
+    /* A curved silhouette gives the ink rounded ends and a gently uneven edge. */
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 20' preserveAspectRatio='none'%3E%3Cpath d='M1 5C16 1 30 4 44 3S76 5 98.8 1Q100 .7 100 4L99.6 14Q99.4 17 98 17C78 20 66 16 48 18S17 17 1.2 20Q0 20 0 17L.4 8Q.5 6 1 5Z'/%3E%3C/svg%3E");
+    mask-size: 100% 100%;
+    mask-repeat: no-repeat;
+  }
+  ::highlight(entropic-fragment) {
+    background-color: transparent;
+  }
+  .fragment-panel {
+    width: max-content;
+    max-width: min(392px, var(--selection-width, calc(100vw - 24px)));
+  }
+  .fragment-kind {
+    color: color-mix(in srgb, var(--fg) 60%, var(--bg));
+  }
+  .fragment-field {
+    position: relative;
+    max-height: min(240px, 40dvh);
+    overflow: hidden;
+  }
+  .fragment-url {
+    display: block;
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    padding: 12px;
+    border: 0;
+    background: transparent;
+    color: var(--link);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    resize: none;
+    scrollbar-width: thin;
+    user-select: text;
+  }
+  /* The same text and typography size the native field in Firefox too,
+     including after a viewport or font change, without resize measurements. */
+  .fragment-url-size {
+    visibility: hidden;
+    user-select: none;
+  }
+  textarea.fragment-url {
+    position: absolute;
+    inset: 0;
+    height: 100%;
+  }
+  .fragment-message {
+    margin: 0;
+    padding: 12px;
+    color: var(--fg);
+  }
+  [data-fragment-status][hidden] {
+    display: none;
+  }
+  .fragment-notice {
+    position: fixed;
+    z-index: 80;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    box-sizing: border-box;
+    width: max-content;
+    max-width: calc(100vw - 24px);
+    margin: 0;
+    padding: 8px 12px;
+    border: 1px solid color-mix(in srgb, var(--link) 40%, var(--bg));
+    background: var(--bg);
+    color: var(--fg);
+    font: 14px / 20px var(--text-font);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .fragment-marker-line {
+      transition: none;
+    }
+  }
+  @media (pointer: coarse) {
+    .phile-selection .fragment-url {
+      font-size: 16px;
+    }
+  }
+}

--- a/src/features/philes/client.ts
+++ b/src/features/philes/client.ts
@@ -1,9 +1,9 @@
 import { initLifeArt } from "@/shared/textmode/life/client";
-import { installByteInspector } from "./inspection/client";
+import { installSelectionTools } from "./selection/client";
 
 export function installPhileInteractions(): void {
   initLifeArt();
-  installByteInspector();
+  installSelectionTools();
   if (document.querySelector("[data-lightbox-image]")) {
     void import("@/shared/textmode/lightbox").then(({ installImageLightbox }) => installImageLightbox());
   }

--- a/src/features/philes/components/ByteInspector.astro
+++ b/src/features/philes/components/ByteInspector.astro
@@ -2,31 +2,20 @@
 import "../inspection/styles.css";
 ---
 
-<div class="byte-inspector" data-byte-inspector hidden>
-  <button
-    type="button"
-    class="byte-inspector-trigger"
-    data-inspect-trigger
-    aria-haspopup="dialog"
-    aria-expanded="false"
-  >
-    [inspect]
-  </button>
-  <section
-    class="byte-inspector-panel"
-    data-inspect-panel
-    role="dialog"
-    aria-label="Byte inspector"
-    tabindex="-1"
-    hidden
-  >
-    <div class="byte-inspector-toolbar">
-      <header class="byte-inspector-heading">
-        <span>INSPECT <span class="byte-inspector-kind" data-inspect-kind></span></span>
-      </header>
-      <div class="byte-inspector-controls" data-inspect-controls></div>
-    </div>
-    <div class="byte-inspector-rows" data-inspect-rows aria-live="polite" aria-atomic="true"></div>
-    <p class="byte-inspector-note" data-inspect-note hidden></p>
-  </section>
-</div>
+<section
+  class="selection-panel byte-inspector-panel"
+  data-inspect-panel
+  role="dialog"
+  aria-label="Byte inspector"
+  tabindex="-1"
+  hidden
+>
+  <div class="byte-inspector-toolbar">
+    <header class="selection-heading">
+      <span>INSPECT <span class="byte-inspector-kind" data-inspect-kind></span></span>
+    </header>
+    <div class="byte-inspector-controls" data-inspect-controls></div>
+  </div>
+  <div class="byte-inspector-rows" data-inspect-rows aria-live="polite" aria-atomic="true"></div>
+  <p class="byte-inspector-note" data-inspect-note hidden></p>
+</section>

--- a/src/features/philes/components/PhileShell.astro
+++ b/src/features/philes/components/PhileShell.astro
@@ -2,7 +2,7 @@
 import { phileConfig } from "@/config/server";
 import type { Phile } from "../model";
 import { renderPhile } from "../rendering";
-import ByteInspector from "./ByteInspector.astro";
+import SelectionTools from "./SelectionTools.astro";
 import "@/shared/textmode/styles/life.css";
 import "@/shared/textmode/styles/ansi.css";
 import "../styles.css";
@@ -35,7 +35,7 @@ const { header, body, footerHtml } = renderPhile(Astro.props.phile);
   <pre class="textmode-pre phile-pre phile-footer-pre" set:html={footerHtml} />
 </article>
 
-{phileConfig.inspect && body.kind !== "redacted" && <ByteInspector />}
+{body.kind !== "redacted" && (phileConfig.inspect || phileConfig.fragmentLinks) && <SelectionTools />}
 
 <script>
   import { installPhileInteractions } from "../client";

--- a/src/features/philes/components/SelectionTools.astro
+++ b/src/features/philes/components/SelectionTools.astro
@@ -1,0 +1,69 @@
+---
+import { phileConfig } from "@/config/server";
+import ByteInspector from "./ByteInspector.astro";
+import "../selection/styles.css";
+import "../citations/styles.css";
+---
+
+<div class="phile-selection" data-selection-tools hidden>
+  <div class="selection-actions" data-selection-actions role="group" aria-label="Selection actions">
+    {
+      phileConfig.inspect && (
+        <button
+          type="button"
+          class="selection-trigger"
+          data-inspect-trigger
+          aria-haspopup="dialog"
+          aria-expanded="false"
+          hidden
+        >
+          [inspect]
+        </button>
+      )
+    }
+    {
+      phileConfig.fragmentLinks && (
+        <button
+          type="button"
+          class="selection-trigger"
+          data-fragment-trigger
+          aria-haspopup="dialog"
+          aria-expanded="false"
+          hidden
+        >
+          [link]
+        </button>
+      )
+    }
+  </div>
+  {phileConfig.inspect && <ByteInspector />}
+  {
+    phileConfig.fragmentLinks && (
+      <section
+        class="selection-panel fragment-panel"
+        data-fragment-panel
+        role="dialog"
+        aria-label="Fragment link"
+        tabindex="-1"
+        hidden
+      >
+        <header class="selection-heading">
+          LINK <span class="fragment-kind">/ SELECTION</span>
+        </header>
+        <div class="fragment-field" data-fragment-field>
+          <span class="fragment-url fragment-url-size" data-fragment-url-size aria-hidden="true" />
+          <textarea
+            class="fragment-url"
+            data-fragment-url
+            aria-label="Link to selected text"
+            rows="1"
+            spellcheck="false"
+            readonly
+          />
+        </div>
+        <p class="fragment-message" data-fragment-message hidden />
+      </section>
+    )
+  }
+</div>
+{phileConfig.fragmentLinks && <p data-fragment-status role="status" aria-live="polite" hidden />}

--- a/src/features/philes/inspection/client.ts
+++ b/src/features/philes/inspection/client.ts
@@ -1,196 +1,49 @@
+import { articleBody, type SelectionTool } from "../selection/types";
 import type { InspectionOptions, PreparedInspection } from "./inspect";
 import { INSPECTION_LIMITS } from "./limits";
 import { createInspectorPanel } from "./panel";
 
-type Candidate = { range: Range; inspection: PreparedInspection };
 let engine: Promise<typeof import("./inspect")> | null = null;
 
-function bodyFor(node: Node): Element | null {
-  const element = node instanceof Element ? node : node.parentElement;
-  return element?.closest(".phile-body-pre:not(.phile-redacted-pre)") ?? null;
-}
-
-function sameRange(first: Range | null, second: Range): boolean {
-  return (
-    first?.startContainer === second.startContainer &&
-    first.startOffset === second.startOffset &&
-    first.endContainer === second.endContainer &&
-    first.endOffset === second.endOffset
-  );
-}
-
-function readSelection(): Range | null {
-  const selection = window.getSelection();
-  if (!selection || selection.isCollapsed || selection.rangeCount !== 1) return null;
-  const range = selection.getRangeAt(0);
-  const body = bodyFor(range.startContainer);
-  return body && body === bodyFor(range.endContainer) ? range : null;
-}
-
-export function installByteInspector(): void {
-  const root = document.querySelector<HTMLElement>("[data-byte-inspector]");
-  if (!root || root.dataset.installed) return;
+export function createInspectionTool(root: HTMLElement, onUpdate: () => void): SelectionTool | null {
   const trigger = root.querySelector<HTMLButtonElement>("[data-inspect-trigger]");
   const panel = root.querySelector<HTMLElement>("[data-inspect-panel]");
-  if (!trigger || !panel) return;
-
-  let candidate: Candidate | null = null;
-  let dismissedRange: Range | null = null;
-  let selectionTimer = 0;
-  let selectionRevision = 0;
-  let placementFrame = 0;
-  let selecting = false;
+  if (!trigger || !panel) return null;
+  let active: PreparedInspection | null = null;
   let options: InspectionOptions = {};
-
   const render = createInspectorPanel(panel, (key, value) => {
-    if (!candidate) return;
+    if (!active) return;
     options[key] = value;
-    render?.(candidate.inspection.render(options));
-    if (!place(candidate.range)) hide();
+    render?.(active.render(options));
+    onUpdate();
   });
-  if (!render) return;
-  root.dataset.installed = "true";
-
-  const hide = (): void => {
-    selectionRevision++;
-    window.clearTimeout(selectionTimer);
-    window.cancelAnimationFrame(placementFrame);
-    placementFrame = 0;
-    if (candidate) dismissedRange = candidate.range;
-    candidate = null;
-    root.hidden = true;
-    panel.hidden = true;
-    trigger.hidden = false;
-    trigger.setAttribute("aria-expanded", "false");
-  };
-
-  const place = (range: Range): boolean => {
-    const rect = range.getBoundingClientRect();
-    const viewport = window.visualViewport;
-    const leftEdge = (viewport?.offsetLeft ?? 0) + 12;
-    const topEdge = (viewport?.offsetTop ?? 0) + 12;
-    const rightEdge = leftEdge + Math.max(1, (viewport?.width ?? document.documentElement.clientWidth) - 24);
-    const bottomEdge = topEdge + Math.max(1, (viewport?.height ?? window.innerHeight) - 24);
-    if (rect.bottom < topEdge || rect.top > bottomEdge || rect.right < leftEdge || rect.left > rightEdge) return false;
-
-    root.style.setProperty("--inspector-width", `${rightEdge - leftEdge}px`);
-    root.style.setProperty("--inspector-height", `${bottomEdge - topEdge}px`);
-    const width = root.offsetWidth;
-    const height = root.offsetHeight;
-    const below = rect.bottom + 8;
-    const above = rect.top - height - 8;
-    const top = below + height <= bottomEdge ? below : Math.max(topEdge, above);
-    root.style.left = `${Math.max(leftEdge, Math.min(rect.left, rightEdge - width))}px`;
-    root.style.top = `${Math.min(top, Math.max(topEdge, bottomEdge - height))}px`;
-    return true;
-  };
-
-  const updateSelection = async (): Promise<void> => {
-    if (selecting || (!panel.hidden && root.contains(document.activeElement))) return;
-    const range = readSelection();
-    if (!range) {
-      if (panel.hidden) {
-        hide();
-        dismissedRange = null;
+  if (!render) return null;
+  return {
+    trigger,
+    panel,
+    async prepare({ range, text }) {
+      if (
+        text.length > INSPECTION_LIMITS.selectionLength ||
+        articleBody(range.startContainer) !== articleBody(range.endContainer)
+      )
+        return null;
+      try {
+        engine ??= import("./inspect");
+        const { prepareInspection } = await engine;
+        const inspection = prepareInspection(text);
+        if (!inspection) return null;
+        const previous: InspectionOptions = {};
+        return {
+          show() {
+            active = inspection;
+            options = previous;
+            render(inspection.render(options));
+          }
+        };
+      } catch {
+        engine = null;
+        return null;
       }
-      return;
-    }
-    if (sameRange(dismissedRange, range) || (candidate && sameRange(candidate.range, range))) return;
-    const source = range.toString();
-    hide();
-    if (source.length > INSPECTION_LIMITS.selectionLength) return;
-    const revision = selectionRevision;
-    const savedRange = range.cloneRange();
-    try {
-      engine ??= import("./inspect");
-      const { prepareInspection } = await engine;
-      // A changed/dismissed selection must not reappear after the first lazy load.
-      if (revision !== selectionRevision) return;
-      const inspection = prepareInspection(source);
-      if (!inspection) return;
-      candidate = { range: savedRange, inspection };
-      options = {};
-      dismissedRange = null;
-      root.hidden = false;
-      if (!place(savedRange)) hide();
-    } catch {
-      engine = null;
-      if (revision === selectionRevision) hide();
     }
   };
-
-  const scheduleSelection = (): void => {
-    selectionRevision++;
-    window.clearTimeout(selectionTimer);
-    selectionTimer = window.setTimeout(() => void updateSelection(), 160);
-  };
-
-  const open = (): void => {
-    if (!candidate) return;
-    render(candidate.inspection.render(options));
-    trigger.hidden = true;
-    trigger.setAttribute("aria-expanded", "true");
-    panel.hidden = false;
-    panel.scrollTop = 0;
-    if (!place(candidate.range)) {
-      hide();
-      return;
-    }
-    panel.focus({ preventScroll: true });
-  };
-
-  const collapsePanel = (): void => {
-    panel.hidden = true;
-    trigger.hidden = false;
-    trigger.setAttribute("aria-expanded", "false");
-    if (candidate && place(candidate.range)) {
-      const selection = window.getSelection();
-      selection?.removeAllRanges();
-      selection?.addRange(candidate.range.cloneRange());
-      trigger.focus({ preventScroll: true });
-    } else hide();
-  };
-
-  const schedulePlacement = (): void => {
-    if (root.hidden || placementFrame) return;
-    placementFrame = window.requestAnimationFrame(() => {
-      placementFrame = 0;
-      if (candidate && !place(candidate.range)) hide();
-    });
-  };
-
-  trigger.addEventListener("pointerdown", (event) => event.preventDefault());
-  trigger.addEventListener("click", open);
-  document.addEventListener("selectionchange", scheduleSelection);
-  document.addEventListener("pointerdown", (event) => {
-    if (event.target instanceof Node && root.contains(event.target)) return;
-    selecting = true;
-    hide();
-    dismissedRange = null;
-  });
-  document.addEventListener("pointerup", () => {
-    selecting = false;
-    scheduleSelection();
-  });
-  document.addEventListener("pointercancel", () => {
-    selecting = false;
-    scheduleSelection();
-  });
-  document.addEventListener("keydown", (event) => {
-    if (event.key === "Escape" && !root.hidden) {
-      event.preventDefault();
-      if (panel.hidden) hide();
-      else collapsePanel();
-    }
-  });
-  document.addEventListener(
-    "scroll",
-    (event) => {
-      if (!(event.target instanceof Node) || !root.contains(event.target)) hide();
-    },
-    true
-  );
-  window.addEventListener("resize", schedulePlacement);
-  window.visualViewport?.addEventListener("resize", schedulePlacement);
-  window.visualViewport?.addEventListener("scroll", schedulePlacement);
 }

--- a/src/features/philes/inspection/styles.css
+++ b/src/features/philes/inspection/styles.css
@@ -1,68 +1,6 @@
 @import "../../../styles/layers.css";
 
 @layer components.features {
-  .byte-inspector {
-    position: fixed;
-    z-index: 80;
-    width: max-content;
-    max-width: var(--inspector-width, calc(100vw - 24px));
-    color: var(--fg);
-    font-family: var(--text-font);
-    font-size: 14px;
-    line-height: 20px;
-    text-align: left;
-  }
-
-  .byte-inspector[hidden],
-  .byte-inspector [hidden] {
-    display: none;
-  }
-
-  .byte-inspector button,
-  .byte-inspector select {
-    border-radius: 0;
-    font: inherit;
-    text-align: inherit;
-    cursor: pointer;
-  }
-
-  .byte-inspector button:focus-visible,
-  .byte-inspector select:focus-visible {
-    outline: 1px solid var(--link);
-    outline-offset: -3px;
-  }
-
-  .byte-inspector-trigger {
-    padding: 4px 8px;
-    border: 1px solid color-mix(in srgb, var(--link) 55%, var(--bg));
-    background: var(--bg);
-    color: var(--link);
-  }
-
-  .byte-inspector-trigger:hover {
-    background: var(--link-hover-bg);
-    color: var(--link-hover);
-  }
-
-  .byte-inspector-panel {
-    box-sizing: border-box;
-    width: 392px;
-    max-width: var(--inspector-width, calc(100vw - 24px));
-    max-height: var(--inspector-height, calc(100dvh - 24px));
-    overflow-y: auto;
-    overscroll-behavior-y: contain;
-    scrollbar-width: thin;
-    border: 1px solid color-mix(in srgb, var(--link) 55%, var(--bg));
-    background: var(--bg);
-    outline: none;
-  }
-
-  .byte-inspector-heading {
-    padding: 8px 12px;
-    border-bottom: 1px solid color-mix(in srgb, var(--link) 22%, var(--bg));
-    color: var(--link);
-  }
-
   .byte-inspector-toolbar {
     position: sticky;
     z-index: 1;
@@ -141,7 +79,6 @@
   }
 
   @media (pointer: coarse) {
-    .byte-inspector-trigger,
     .byte-inspector-row,
     .byte-inspector-controls select {
       min-height: 44px;

--- a/src/features/philes/selection/client.ts
+++ b/src/features/philes/selection/client.ts
@@ -1,0 +1,206 @@
+import { createCitationTool } from "../citations/client";
+import { CITATION_LIMITS } from "../citations/limits";
+import { createInspectionTool } from "../inspection/client";
+import { articleBody, type PreparedTool, type SelectionTool } from "./types";
+
+type Candidate = { range: Range; tools: Map<SelectionTool, PreparedTool>; lifetime: AbortController };
+
+function sameRange(first: Range | null, second: Range): boolean {
+  return (
+    first?.startContainer === second.startContainer &&
+    first.startOffset === second.startOffset &&
+    first.endContainer === second.endContainer &&
+    first.endOffset === second.endOffset
+  );
+}
+
+function readSelection(): Range | null {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount !== 1) return null;
+  const range = selection.getRangeAt(0);
+  const start = articleBody(range.startContainer);
+  const end = articleBody(range.endContainer);
+  return start && end && start.closest(".phile-wrap") === end.closest(".phile-wrap") ? range : null;
+}
+
+export function installSelectionTools(): void {
+  const root = document.querySelector<HTMLElement>("[data-selection-tools]");
+  const actions = root?.querySelector<HTMLElement>("[data-selection-actions]");
+  if (!root || !actions || root.dataset.installed) return;
+  let candidate: Candidate | null = null;
+  let active: SelectionTool | null = null;
+  let dismissedRange: Range | null = null;
+  let selectionTimer = 0;
+  let selectionRevision = 0;
+  let openRevision = 0;
+  let placementFrame = 0;
+  let selecting = false;
+
+  const tools = [
+    createInspectionTool(root, () => {
+      if (candidate && !place(candidate.range)) hide();
+    }),
+    createCitationTool(root)
+  ].filter((tool): tool is SelectionTool => tool !== null);
+  if (!tools.length) return;
+  root.dataset.installed = "true";
+
+  const hide = (): void => {
+    selectionRevision++;
+    openRevision++;
+    clearTimeout(selectionTimer);
+    cancelAnimationFrame(placementFrame);
+    placementFrame = 0;
+    if (candidate) dismissedRange = candidate.range;
+    candidate?.lifetime.abort();
+    candidate = null;
+    active = null;
+    if (root.hidden) return;
+    root.hidden = true;
+    actions.hidden = false;
+    for (const { trigger, panel } of tools) {
+      panel.hidden = true;
+      trigger.hidden = true;
+      trigger.removeAttribute("aria-busy");
+      trigger.setAttribute("aria-expanded", "false");
+    }
+  };
+
+  const place = (range: Range): boolean => {
+    const rect = range.getBoundingClientRect();
+    const viewport = window.visualViewport;
+    const leftEdge = (viewport?.offsetLeft ?? 0) + 12;
+    const topEdge = (viewport?.offsetTop ?? 0) + 12;
+    const rightEdge = leftEdge + Math.max(1, (viewport?.width ?? document.documentElement.clientWidth) - 24);
+    const bottomEdge = topEdge + Math.max(1, (viewport?.height ?? innerHeight) - 24);
+    if (rect.bottom < topEdge || rect.top > bottomEdge || rect.right < leftEdge || rect.left > rightEdge) return false;
+    root.style.setProperty("--selection-width", `${rightEdge - leftEdge}px`);
+    root.style.setProperty("--selection-height", `${bottomEdge - topEdge}px`);
+    const width = root.offsetWidth;
+    const height = root.offsetHeight;
+    const below = rect.bottom + 8;
+    const above = rect.top - height - 8;
+    const top = below + height <= bottomEdge ? below : Math.max(topEdge, above);
+    root.style.left = `${Math.max(leftEdge, Math.min(rect.left, rightEdge - width))}px`;
+    root.style.top = `${Math.min(top, Math.max(topEdge, bottomEdge - height))}px`;
+    return true;
+  };
+
+  const updateSelection = async (): Promise<void> => {
+    if (selecting || (active && root.contains(document.activeElement))) return;
+    const range = readSelection();
+    if (!range) {
+      if (!active) {
+        hide();
+        dismissedRange = null;
+      }
+      return;
+    }
+    if (sameRange(dismissedRange, range) || (candidate && sameRange(candidate.range, range))) return;
+    const text = range.toString();
+    hide();
+    if (text.length > CITATION_LIMITS.selection) return;
+    const revision = selectionRevision;
+    const savedRange = range.cloneRange();
+    const prepared = await Promise.all(
+      tools.map(async (tool) => ({ tool, view: await tool.prepare({ range: savedRange, text }) }))
+    );
+    if (revision !== selectionRevision) return;
+    const available = new Map<SelectionTool, PreparedTool>();
+    for (const { tool, view } of prepared) {
+      tool.trigger.hidden = !view;
+      if (view) available.set(tool, view);
+    }
+    if (!available.size) return;
+    candidate = { range: savedRange, tools: available, lifetime: new AbortController() };
+    dismissedRange = null;
+    root.hidden = false;
+    if (!place(savedRange)) hide();
+  };
+
+  const scheduleSelection = (): void => {
+    selectionRevision++;
+    clearTimeout(selectionTimer);
+    selectionTimer = window.setTimeout(() => void updateSelection(), 160);
+  };
+
+  const open = async (tool: SelectionTool): Promise<void> => {
+    const current = candidate;
+    const view = current?.tools.get(tool);
+    if (!current || !view || active) return;
+    active = tool;
+    const revision = ++openRevision;
+    tool.trigger.setAttribute("aria-busy", "true");
+    await view.show(current.lifetime.signal);
+    if (candidate !== current || revision !== openRevision) return;
+    tool.trigger.removeAttribute("aria-busy");
+    tool.trigger.setAttribute("aria-expanded", "true");
+    actions.hidden = true;
+    tool.panel.hidden = false;
+    tool.panel.scrollTop = 0;
+    if (!place(current.range)) {
+      hide();
+      return;
+    }
+    tool.panel.focus({ preventScroll: true });
+  };
+
+  const collapsePanel = (): void => {
+    const previous = active;
+    if (!previous) return;
+    openRevision++;
+    previous.panel.hidden = true;
+    previous.trigger.setAttribute("aria-expanded", "false");
+    previous.trigger.removeAttribute("aria-busy");
+    active = null;
+    actions.hidden = false;
+    if (candidate && place(candidate.range)) {
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(candidate.range.cloneRange());
+      previous.trigger.focus({ preventScroll: true });
+    } else hide();
+  };
+
+  const schedulePlacement = (): void => {
+    if (root.hidden || placementFrame) return;
+    placementFrame = requestAnimationFrame(() => {
+      placementFrame = 0;
+      if (candidate && !place(candidate.range)) hide();
+    });
+  };
+  for (const tool of tools) {
+    tool.trigger.addEventListener("pointerdown", (event) => event.preventDefault());
+    tool.trigger.addEventListener("click", () => void open(tool));
+  }
+  document.addEventListener("selectionchange", scheduleSelection);
+  document.addEventListener("pointerdown", (event) => {
+    if (event.target instanceof Node && root.contains(event.target)) return;
+    selecting = true;
+    hide();
+    dismissedRange = null;
+  });
+  const finishSelection = (): void => {
+    selecting = false;
+    scheduleSelection();
+  };
+  document.addEventListener("pointerup", finishSelection);
+  document.addEventListener("pointercancel", finishSelection);
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && !root.hidden) {
+      event.preventDefault();
+      if (active) collapsePanel();
+      else hide();
+    }
+  });
+  document.addEventListener(
+    "scroll",
+    (event) => {
+      if (!(event.target instanceof Node) || !root.contains(event.target)) hide();
+    },
+    true
+  );
+  window.addEventListener("resize", schedulePlacement);
+  window.visualViewport?.addEventListener("resize", schedulePlacement);
+  window.visualViewport?.addEventListener("scroll", schedulePlacement);
+}

--- a/src/features/philes/selection/styles.css
+++ b/src/features/philes/selection/styles.css
@@ -1,0 +1,71 @@
+@import "../../../styles/layers.css";
+
+@layer components.features {
+  .phile-selection {
+    position: fixed;
+    z-index: 80;
+    width: max-content;
+    max-width: var(--selection-width, calc(100vw - 24px));
+    color: var(--fg);
+    font-family: var(--text-font);
+    font-size: 14px;
+    line-height: 20px;
+    text-align: left;
+  }
+  .phile-selection[hidden],
+  .phile-selection [hidden] {
+    display: none;
+  }
+  .phile-selection button,
+  .phile-selection select,
+  .phile-selection textarea {
+    border-radius: 0;
+    font: inherit;
+    text-align: inherit;
+  }
+  .phile-selection button,
+  .phile-selection select {
+    cursor: pointer;
+  }
+  .phile-selection :is(button, select, textarea):focus-visible {
+    outline: 1px solid var(--link);
+    outline-offset: -3px;
+  }
+  .selection-actions {
+    display: flex;
+    border: 1px solid color-mix(in srgb, var(--link) 55%, var(--bg));
+    background: var(--bg);
+  }
+  .selection-trigger {
+    padding: 4px 8px;
+    border: 0;
+    background: transparent;
+    color: var(--link);
+  }
+  .selection-trigger:hover {
+    background: var(--link-hover-bg);
+    color: var(--link-hover);
+  }
+  .selection-panel {
+    box-sizing: border-box;
+    width: 392px;
+    max-width: var(--selection-width, calc(100vw - 24px));
+    max-height: var(--selection-height, calc(100dvh - 24px));
+    overflow-y: auto;
+    overscroll-behavior-y: contain;
+    scrollbar-width: thin;
+    border: 1px solid color-mix(in srgb, var(--link) 55%, var(--bg));
+    background: var(--bg);
+    outline: none;
+  }
+  .selection-heading {
+    padding: 8px 12px;
+    border-bottom: 1px solid color-mix(in srgb, var(--link) 22%, var(--bg));
+    color: var(--link);
+  }
+  @media (pointer: coarse) {
+    .selection-trigger {
+      min-height: 44px;
+    }
+  }
+}

--- a/src/features/philes/selection/types.ts
+++ b/src/features/philes/selection/types.ts
@@ -1,0 +1,15 @@
+export const ARTICLE_TEXT = ".phile-body-pre:not(.phile-redacted-pre)";
+export type ArticleSelection = { range: Range; text: string };
+export type PreparedTool = { show: (signal: AbortSignal) => void | Promise<void> };
+
+/** Tools own their content; the shared selection controller owns interaction. */
+export type SelectionTool = {
+  trigger: HTMLButtonElement;
+  panel: HTMLElement;
+  prepare: (selection: ArticleSelection) => PreparedTool | null | Promise<PreparedTool | null>;
+};
+
+export function articleBody(node: Node): Element | null {
+  const element = node instanceof Element ? node : node.parentElement;
+  return element?.closest(ARTICLE_TEXT) ?? null;
+}

--- a/tests/browser/byte-inspector.mjs
+++ b/tests/browser/byte-inspector.mjs
@@ -1,33 +1,12 @@
 import assert from "node:assert/strict";
-import { baseUrl, browserName, launchBrowser, settleTextLayout, stubExternalResources } from "./support.mjs";
-
-async function selectText(page, text, selector = ".phile-body-pre") {
-  await page.evaluate(
-    async ({ text, selector }) => {
-      const element = [...document.querySelectorAll(selector)].find((node) => node.textContent.includes(text));
-      if (!element) throw new Error(`Missing article text: ${text}`);
-      const start = element.textContent.indexOf(text);
-      const end = start + text.length;
-      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
-      const range = document.createRange();
-      let offset = 0;
-      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-        const next = offset + node.textContent.length;
-        if (start >= offset && start < next) range.setStart(node, start - offset);
-        if (end > offset && end <= next) {
-          range.setEnd(node, end - offset);
-          break;
-        }
-        offset = next;
-      }
-      window.getSelection().removeAllRanges();
-      window.scrollBy(0, range.getBoundingClientRect().top - window.innerHeight / 3);
-      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-      window.getSelection().addRange(range);
-    },
-    { text, selector }
-  );
-}
+import {
+  baseUrl,
+  browserName,
+  launchBrowser,
+  selectArticleText,
+  settleTextLayout,
+  stubExternalResources
+} from "./support.mjs";
 
 const browser = await launchBrowser();
 const errors = [];
@@ -41,7 +20,7 @@ try {
     await settleTextLayout(page);
     const trigger = page.locator("[data-inspect-trigger]");
     const panel = page.getByRole("dialog", { name: "Byte inspector" });
-    const root = page.locator("[data-byte-inspector]");
+    const root = page.locator("[data-selection-tools]");
     assert.equal(await root.isVisible(), false, "Reading alone never opens the inspector");
 
     // Exercise native Copy/Paste in this isolated browser, without a clipboard API mock.
@@ -57,7 +36,7 @@ try {
     await copyProbe.press("Control+c");
     await copyProbe.evaluate((field) => field.blur());
 
-    await selectText(page, "00 02 00 00");
+    await selectArticleText(page, "00 02 00 00");
     await trigger.waitFor({ state: "visible" });
     await trigger.click();
     await panel.waitFor({ state: "visible" });
@@ -81,7 +60,7 @@ try {
     assert.equal(await copyProbe.inputValue(), "512", "Native Copy transfers the selected value");
     await copyProbe.evaluate((field) => field.remove());
 
-    await selectText(page, "00 02 00 00 88 df 74 2f");
+    await selectArticleText(page, "00 02 00 00 88 df 74 2f");
     await trigger.waitFor({ state: "visible" });
     await trigger.click();
     await panel.waitFor({ state: "visible" });
@@ -89,7 +68,7 @@ try {
     await page.evaluate(() => window.scrollBy(0, 80));
     await root.waitFor({ state: "hidden" });
 
-    await selectText(page, "0x20000");
+    await selectArticleText(page, "0x20000");
     await trigger.waitFor({ state: "visible" });
     await trigger.click();
     assert.equal(await page.locator("[data-inspect-kind]").textContent(), "/ INTEGER");
@@ -109,17 +88,17 @@ try {
     );
 
     await page.mouse.click(1, 100);
-    await selectText(page, "AES-CBC");
+    await selectArticleText(page, "AES-CBC");
     // Selection handling is debounced until a drag/keyboard selection settles.
     await page.waitForTimeout(250);
-    assert.equal(await root.isVisible(), false, "Prose does not activate the inspector");
-    await selectText(page, "0", ".phile-header-meta");
+    assert.equal(await trigger.isVisible(), false, "Prose does not activate the inspector");
+    await selectArticleText(page, "0", ".phile-header-meta");
     await page.waitForTimeout(250);
     assert.equal(await root.isVisible(), false, "Header metadata is outside the reading tool");
 
     await page.goto(new URL("/volume/3/inspect-field-notes/", baseUrl).href);
     await settleTextLayout(page);
-    await selectText(page, "-1");
+    await selectArticleText(page, "-1");
     await trigger.waitFor({ state: "visible" });
     await trigger.click();
     await page.getByRole("combobox", { name: "Bit width", exact: true }).selectOption("16");
@@ -135,7 +114,7 @@ try {
     );
     await page.mouse.click(1, 100);
 
-    await selectText(page, "-1 < 0U");
+    await selectArticleText(page, "-1 < 0U");
     await trigger.waitFor({ state: "visible" });
     await trigger.click();
     assert.ok(await page.getByRole("button", { name: "Select LEFT: 4294967295", exact: true }).isVisible());
@@ -145,7 +124,7 @@ try {
     assert.ok(comparisonBox.y >= 0 && comparisonBox.y + comparisonBox.height <= 800);
     await page.mouse.click(1, 100);
 
-    await selectText(page, "00 80 34 41");
+    await selectArticleText(page, "00 80 34 41");
     await trigger.waitFor({ state: "visible" });
     await trigger.click();
     await page.getByRole("combobox", { name: "View", exact: true }).selectOption("float32");
@@ -154,13 +133,13 @@ try {
     assert.ok(await page.getByRole("button", { name: "Select HEX: 0x00803441", exact: true }).isVisible());
     await page.mouse.click(1, 100);
 
-    await selectText(page, "0.1f");
+    await selectArticleText(page, "0.1f");
     await trigger.waitFor({ state: "visible" });
     await trigger.click();
     assert.ok(await page.getByRole("button", { name: "Select VALUE: 0.10000000149011612", exact: true }).isVisible());
     await page.mouse.click(1, 100);
 
-    await selectText(page, "c3 a9");
+    await selectArticleText(page, "c3 a9");
     await trigger.waitFor({ state: "visible" });
     await trigger.click();
     await page.getByRole("combobox", { name: "View", exact: true }).selectOption("text");
@@ -190,15 +169,15 @@ try {
     await page.goto(new URL("/volume/3/inspect-field-notes/", baseUrl).href);
     await settleTextLayout(page);
     const loading = page.waitForRequest((request) => engineUrl(new URL(request.url())));
-    await selectText(page, "-1");
+    await selectArticleText(page, "-1");
     const request = await loading;
     await page.touchscreen.tap(1, 100);
     gate.resolve();
     await page.evaluate((url) => import(url).then(() => true), request.url());
-    const root = page.locator("[data-byte-inspector]");
+    const root = page.locator("[data-selection-tools]");
     assert.equal(await root.isVisible(), false, "Canceled selection stays closed after a delayed engine load");
 
-    await selectText(page, "0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0");
+    await selectArticleText(page, "0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0");
     const trigger = page.locator("[data-inspect-trigger]");
     await trigger.waitFor({ state: "visible" });
     await trigger.tap();

--- a/tests/browser/fragment-citations.mjs
+++ b/tests/browser/fragment-citations.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import {
+  baseUrl,
+  browserName,
+  launchBrowser,
+  selectArticleText,
+  settleTextLayout,
+  stubExternalResources
+} from "./support.mjs";
+
+const browser = await launchBrowser();
+const errors = [];
+const route = "/volume/3/inspect-field-notes/";
+const quote = "Width and rank both matter.";
+
+async function openLink(page, text) {
+  await selectArticleText(page, text);
+  await page.locator("[data-fragment-trigger]").click();
+  const field = page.getByRole("textbox", { name: "Link to selected text" });
+  await field.waitFor({ state: "visible" });
+  return field.inputValue();
+}
+
+async function highlighted(page) {
+  await page.waitForFunction(() => CSS.highlights?.has("entropic-fragment"));
+  return page.evaluate(() => {
+    const range = [...CSS.highlights.get("entropic-fragment")][0];
+    const bounds = range.getBoundingClientRect();
+    const stroke = document.querySelector(".fragment-marker-line")?.getBoundingClientRect();
+    // Range endpoints measure the hidden fallback font; bitmap glyphs can be wider.
+    const firstGlyph = range.startContainer.parentElement?.closest(".cjk-bitmap")?.getBoundingClientRect();
+    const lastGlyph = range.endContainer.parentElement?.closest(".cjk-bitmap")?.getBoundingClientRect();
+    const painted = {
+      left: firstGlyph?.left ?? bounds.left,
+      right: lastGlyph?.right ?? bounds.right,
+      top: Math.min(firstGlyph?.top ?? bounds.top, lastGlyph?.top ?? bounds.top),
+      bottom: Math.max(firstGlyph?.bottom ?? bounds.bottom, lastGlyph?.bottom ?? bounds.bottom)
+    };
+    return {
+      text: range.toString(),
+      top: bounds.top,
+      strokes: document.querySelectorAll(".fragment-marker-line").length,
+      aligned: !!stroke && ["left", "right", "top", "bottom"].every((key) => Math.abs(stroke[key] - painted[key]) < 1)
+    };
+  });
+}
+
+try {
+  for (const width of [1280, 320]) {
+    const context = await browser.newContext({ viewport: { width, height: 800 }, reducedMotion: "reduce" });
+    await stubExternalResources(context);
+    const page = await context.newPage();
+    page.on("pageerror", (error) => errors.push(error.message));
+    const requests = [];
+    page.on("request", (request) => requests.push(new URL(request.url()).pathname));
+    await page.goto(new URL(route, baseUrl).href);
+    await settleTextLayout(page);
+    assert.equal(
+      requests.some((path) => /\/(?:citations\/document\.ts|_astro\/document\.[^/]+\.js)$/.test(path)),
+      false,
+      "Ordinary reading does not load the quote index"
+    );
+    const html = await page.locator(".phile-body-pre").innerHTML();
+    const url = await openLink(page, quote);
+    assert.equal(new URL(url).hash, "#cite=Width+and+rank+both+matter.");
+    const panel = page.getByRole("dialog", { name: "Fragment link", exact: true });
+    const field = page.getByRole("textbox", { name: "Link to selected text" });
+    const box = await panel.boundingBox();
+    assert.ok(
+      box.x >= 0 && box.x + box.width <= width && box.y >= 0 && box.y + box.height <= 800,
+      "Link panel fits the viewport"
+    );
+    await field.click();
+    assert.deepEqual(await field.evaluate((node) => [node.selectionStart, node.selectionEnd]), [0, url.length]);
+    await page.keyboard.press("Control+c");
+    await page.keyboard.press("Escape");
+    assert.equal(await page.evaluate(() => getSelection().toString()), quote, "Escape restores the passage");
+    assert.ok(await page.locator("[data-fragment-trigger]").evaluate((node) => node === document.activeElement));
+    await page.keyboard.press("Enter");
+    await panel.waitFor({ state: "visible" });
+    await page.mouse.click(1, 100);
+    await page.evaluate(() => {
+      const probe = document.createElement("textarea");
+      probe.dataset.copyProbe = "";
+      probe.style.cssText = "position:fixed;bottom:0;left:0;width:120px;height:24px;z-index:999";
+      document.body.append(probe);
+      probe.focus();
+    });
+    await page.keyboard.press("Control+v");
+    assert.equal(await page.locator("[data-copy-probe]").inputValue(), url, "Native Copy/Paste transfers the URL");
+    await page.locator("[data-copy-probe]").evaluate((node) => node.remove());
+
+    await selectArticleText(page, "-1");
+    await page.locator("[data-inspect-trigger]").click();
+    await page.getByRole("combobox", { name: "Bit width", exact: true }).selectOption("16");
+    await page.keyboard.press("Escape");
+    await page.locator("[data-fragment-trigger]").click();
+    await field.waitFor({ state: "visible" });
+    const repeatedUrl = await field.inputValue();
+    assert.ok(new URL(repeatedUrl).hash.includes("prefix="), "Repeated numbers carry context");
+    await page.keyboard.press("Escape");
+    await page.locator("[data-inspect-trigger]").click();
+    assert.equal(
+      await page.getByRole("combobox", { name: "Bit width", exact: true }).inputValue(),
+      "16",
+      "Switching tools retains inspector choices and the original range"
+    );
+
+    await page.goto("about:blank");
+    await page.goto(url);
+    const target = await highlighted(page);
+    assert.equal(target.text, quote);
+    assert.ok(Math.abs(target.top - 200) <= 2, "Fresh navigation locates the passage after text fitting");
+    assert.equal(target.strokes, 1, "The quoted line has one marker stroke");
+    assert.ok(target.aligned, "The marker follows the text through responsive zoom");
+    assert.equal(await page.locator(".phile-body-pre").innerHTML(), html, "Highlighting preserves article markup");
+    await page.setViewportSize({ width: width === 1280 ? 960 : 390, height: 800 });
+    await settleTextLayout(page);
+    assert.ok((await highlighted(page)).aligned, "An active marker stays aligned after resizing");
+    await page.waitForFunction(() => !CSS.highlights.has("entropic-fragment"));
+    assert.equal(await page.locator(".fragment-marker").count(), 0, "The temporary marker is removed after fading");
+
+    await page.goto(repeatedUrl);
+    assert.equal((await highlighted(page)).text, "-1", "A new fragment restores its own passage");
+    await page.keyboard.press("ArrowDown");
+    assert.equal(await page.locator(".fragment-marker").count(), 0, "Reader input dismisses the marker");
+
+    await page.goto(new URL(`${route}#cite=this-passage-was-removed`, baseUrl).href);
+    const notice = page.locator("[data-fragment-status]");
+    await notice.filter({ hasText: "The linked passage has changed." }).waitFor({ state: "visible" });
+    assert.equal(await page.evaluate(() => CSS.highlights.has("entropic-fragment")), false);
+    await context.close();
+    console.log(
+      `PASS ${browserName} ${width}px: native link copy, shared selection, contextual links, navigation, highlight cleanup`
+    );
+  }
+
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    isMobile: browserName === "chromium",
+    reducedMotion: "reduce"
+  });
+  await stubExternalResources(context);
+  const page = await context.newPage();
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.goto(new URL("/volume/0/netgear-exs27-0/", baseUrl).href);
+  const codeUrl = await openLink(page, "00 02 00 00 88 df 74 2f");
+  await page.goto("about:blank");
+  await page.goto(codeUrl);
+  assert.equal((await highlighted(page)).text, "00 02 00 00 88 df 74 2f", "A quote crosses ANSI spans");
+  await page.goto(new URL("/volume/1/csapp/", baseUrl).href);
+  await settleTextLayout(page);
+  const cjk = "不开心，不想说话";
+  await selectArticleText(page, cjk);
+  const trigger = page.locator("[data-fragment-trigger]");
+  await trigger.tap();
+  const field = page.getByRole("textbox", { name: "Link to selected text" });
+  await field.waitFor({ state: "visible" });
+  const cjkUrl = await field.inputValue();
+  await field.tap();
+  assert.deepEqual(await field.evaluate((node) => [node.selectionStart, node.selectionEnd]), [0, cjkUrl.length]);
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > innerWidth), false);
+  await page.goto("about:blank");
+  await page.goto(cjkUrl);
+  const cjkTarget = await highlighted(page);
+  assert.equal(cjkTarget.text, cjk, "CJK bitmap spans retain searchable original text");
+  assert.ok(cjkTarget.aligned, "The marker follows the bitmap glyph boxes");
+  const acrossBlocks = await page.evaluate(async () => {
+    const [first, second] = document.querySelectorAll(".phile-body-pre");
+    const range = document.createRange();
+    range.setStart(first, first.childNodes.length - 1);
+    range.setEnd(second.firstChild, Math.min(80, second.firstChild.length));
+    window.scrollBy(0, range.getBoundingClientRect().top - innerHeight / 3);
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    getSelection().removeAllRanges();
+    getSelection().addRange(range);
+    return range.toString().replace(/\s+/gu, "");
+  });
+  await trigger.tap();
+  await field.waitFor({ state: "visible" });
+  const blocksUrl = await field.inputValue();
+  await page.goto("about:blank");
+  await page.goto(blocksUrl);
+  assert.equal(
+    (await highlighted(page)).text.replace(/\s+/gu, ""),
+    acrossBlocks,
+    "Element boundaries and separate text blocks share one quote index"
+  );
+  await context.close();
+  console.log(`PASS ${browserName} touch: ANSI and CJK passages, URL selection, viewport bounds`);
+  assert.deepEqual(errors, [], "Browser exceptions");
+} finally {
+  await browser.close();
+}

--- a/tests/browser/run.mjs
+++ b/tests/browser/run.mjs
@@ -5,3 +5,4 @@ await import("./site-badges.mjs");
 await import("./badge-copy.mjs");
 await import("./artwork-rotation.mjs");
 await import("./byte-inspector.mjs");
+await import("./fragment-citations.mjs");

--- a/tests/browser/support.mjs
+++ b/tests/browser/support.mjs
@@ -31,3 +31,31 @@ export function stubExternalResources(context) {
     });
   });
 }
+
+export async function selectArticleText(page, text, selector = ".phile-body-pre") {
+  await page.evaluate(
+    async ({ text, selector }) => {
+      const element = [...document.querySelectorAll(selector)].find((node) => node.textContent.includes(text));
+      if (!element) throw new Error(`Missing article text: ${text}`);
+      const start = element.textContent.indexOf(text);
+      const end = start + text.length;
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+      const range = document.createRange();
+      let offset = 0;
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        const next = offset + node.textContent.length;
+        if (start >= offset && start < next) range.setStart(node, start - offset);
+        if (end > offset && end <= next) {
+          range.setEnd(node, end - offset);
+          break;
+        }
+        offset = next;
+      }
+      window.getSelection().removeAllRanges();
+      window.scrollBy(0, range.getBoundingClientRect().top - window.innerHeight / 3);
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      window.getSelection().addRange(range);
+    },
+    { text, selector }
+  );
+}

--- a/tests/configuration/config.test.ts
+++ b/tests/configuration/config.test.ts
@@ -43,7 +43,7 @@ test("undefined optional settings inherit defaults, including nested theme field
   const config = resolveConfig({
     site,
     home: { asciiArt: undefined, sectionPrefix: undefined, itemPrefix: undefined },
-    philes: { inspect: undefined },
+    philes: { inspect: undefined, fragmentLinks: undefined },
     theme: {
       appearance: {
         colors: { background: undefined, link: undefined },
@@ -152,11 +152,17 @@ test("WKD can be disabled without deleting its email or public key path", () => 
   assert.deepEqual(resolveConfig({ site, wkd }).wkd, wkd);
 });
 
-test("article inspection defaults to enabled and accepts an explicit opt-out", () => {
-  assert.equal(resolveConfig({ site }).philes.inspect, true);
-  assert.equal(resolveConfig({ site, philes: { inspect: false } }).philes.inspect, false);
+test("article tools default to enabled and can be disabled independently", () => {
+  assert.deepEqual(resolveConfig({ site }).philes, { inspect: true, fragmentLinks: true });
+  assert.deepEqual(resolveConfig({ site, philes: { inspect: false } }).philes, { inspect: false, fragmentLinks: true });
+  assert.deepEqual(resolveConfig({ site, philes: { fragmentLinks: false } }).philes, {
+    inspect: true,
+    fragmentLinks: false
+  });
   // @ts-expect-error Check the runtime boundary for JavaScript configuration too.
   assert.throws(() => resolveConfig({ site, philes: { inspect: "false" } }), /philes.inspect/);
+  // @ts-expect-error Check the runtime boundary for JavaScript configuration too.
+  assert.throws(() => resolveConfig({ site, philes: { fragmentLinks: "false" } }), /philes.fragmentLinks/);
 });
 
 test("a minimal configuration creates a new site without inheriting the theme author's links or records", () => {

--- a/tests/philes/citations.test.ts
+++ b/tests/philes/citations.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createQuoteIndex } from "../../src/features/philes/citations/quotes";
+
+function link(source: string, quote: string, start = source.indexOf(quote)): string {
+  const fragment = createQuoteIndex(source).create(start, start + quote.length);
+  assert.ok(fragment, `Link for ${quote}`);
+  return fragment;
+}
+
+function quoted(source: string, fragment: string): string {
+  const match = createQuoteIndex(source).resolve(fragment);
+  assert.equal(match?.status, "found");
+  if (match?.status !== "found") throw new Error("Missing quote");
+  return source.slice(match.start, match.end);
+}
+
+test("passage links survive insertions, hard wraps and indentation, including CJK", () => {
+  const source = "Before\n    Read the bytes, then\n    check the boundary.\n字节顺序 matters.\nAfter";
+  const fragment = link(source, "    Read the bytes, then\n    check the boundary.\n");
+  assert.equal(new URLSearchParams(fragment.slice(1)).size, 1, "Unique text needs no context");
+  const edited = "A newly inserted paragraph.\nBefore\nRead the\nbytes, then check the boundary.\n字节\n顺序 matters.";
+  assert.equal(quoted(edited, fragment), "Read the\nbytes, then check the boundary.");
+  assert.equal(quoted(edited, link(source, "字节顺序")), "字节\n顺序");
+});
+
+test("repeated text uses context and never falls back to an arbitrary occurrence", () => {
+  const source = "first call: read(fd, buf, n);\nsecond call: read(fd, buf, n);\nend";
+  const fragment = link(source, "read", source.lastIndexOf("read"));
+  const match = createQuoteIndex(source).resolve(fragment);
+  assert.deepEqual(match, { status: "found", start: source.lastIndexOf("read"), end: source.lastIndexOf("read") + 4 });
+  assert.deepEqual(createQuoteIndex(source).resolve("#cite=read"), { status: "ambiguous" });
+  assert.deepEqual(createQuoteIndex(`${source}\n${source}`).resolve(fragment), { status: "ambiguous" });
+  assert.deepEqual(createQuoteIndex(source.replace("second call", "changed call")).resolve(fragment), {
+    status: "missing"
+  });
+  const repeated = "x".repeat(1000);
+  assert.equal(createQuoteIndex(repeated).create(400, 410), null, "No unique context within the limit");
+});
+
+test("code punctuation and Unicode round-trip, while letter case stays significant", () => {
+  for (const quote of ["if (ptr != NULL) { *ptr = 0xff; }", "a+b & c#d ? x/y : 100%", "é e\u0301 🦊 字节"]) {
+    const source = `prefix\n${quote}\nsuffix`;
+    const fragment = link(source, quote);
+    assert.equal(quoted(source, fragment), quote);
+    assert.equal(quoted(source, new URL(`https://example.org/phile/${fragment}`).hash), quote);
+  }
+  assert.deepEqual(createQuoteIndex("null").resolve(link("NULL", "NULL")), { status: "missing" });
+});
+
+test("unrelated anchors, malformed fragments and oversized selections are bounded", () => {
+  const index = createQuoteIndex("example");
+  assert.equal(index.resolve("#chapter-1"), null);
+  for (const fragment of [
+    "#cite=",
+    "#cite=%ZZ",
+    "#cite=%ED%A0%80",
+    "#cite=example&cite=other",
+    "#cite=example&url=x",
+    `#cite=${"x".repeat(12001)}`
+  ]) {
+    assert.deepEqual(index.resolve(fragment), { status: "invalid" });
+  }
+  assert.deepEqual(index.resolve("#cite=removed"), { status: "missing" });
+  assert.equal(index.create(-1, 4), null);
+  assert.equal(index.create(2, 1), null);
+  assert.equal(createQuoteIndex("\n  \t").create(0, 4), null);
+  assert.equal(createQuoteIndex("x".repeat(1025)).create(0, 1025), null);
+});


### PR DESCRIPTION
Readers can select an article passage and use `[link]` to share a URL that returns to that text with a brief green marker highlight. Links survive hard wraps and indentation; repeated text carries context, while changed or ambiguous passages show a short notice.

The link panel sizes itself to its URL and supports native copying. Selection handling is shared with the inspector, including Escape and focus restoration. `philes.fragmentLinks` enables or disables both outgoing links and incoming passage navigation independently of inspection.

Quote indexes load on demand. Rendering caches the selected text ranges, reuses marker nodes across layout changes, and releases temporary listeners and observers when the reader resumes reading. Hidden selection controls avoid repeated DOM writes during scrolling.

Validation: `pnpm check`, 74 regression tests, production build, Chromium passage-link checks, and Firefox passage-link and inspector checks at desktop, narrow, and touch viewports. Browser checks cover native Copy/Paste, ANSI and CJK text, contextual links, resize alignment, cancellation, and cleanup.
