### PR TITLE
feat(content): derive article credits from Git history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm, Node.js, and dependencies
         uses: pnpm/setup@v2.1.0
@@ -78,6 +80,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm, Node.js, and dependencies
         uses: pnpm/setup@v2.1.0

--- a/README
+++ b/README
@@ -87,7 +87,6 @@ Required fields:
 
     title
     date
-    author
 
 Optional fields:
 
@@ -95,6 +94,18 @@ Optional fields:
     slug
     redacted
     lang
+
+Credits come from each file's Git history, including renames and
+Co-authored-by trailers.  The original author appears first, followed by
+contributors in order of first participation.  GitHub nicknames are preferred;
+accounts without a nickname use their login.  Unlinked identities keep their
+Git author name.  A new, uncommitted article has no credits yet.
+
+Names are resolved once per production build and embedded in the static pages.
+No GitHub requests run in the browser.  Builds restore shallow history before
+reading credits; Vercel checkouts without an origin use its Git system variables.
+An optional build-time GITHUB_TOKEN increases the API request allowance.  Cached
+profiles provide a fallback when GitHub is unavailable.
 
 The body is rendered as textmode content.  It preserves layout, wraps to the
 configured article width, renders images, accepts ANSI escape sequences, and
@@ -109,7 +120,6 @@ Example:
     ---
     title: "Example"
     date: 2026-05-31
-    author: "CuB3y0nd"
     ---
 
     --[ Summary ]-------------------------------------------------------------

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -4,6 +4,7 @@ import { config } from "./src/config/server.ts";
 import { cvePagePath } from "./src/features/cves/index.ts";
 
 export default defineConfig({
+  output: "static",
   site: config.site.url,
   // Astro must reload its own site URL when the application config changes.
   integrations: [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "astro dev",
-    "build": "pnpm check && astro build",
+    "build": "node scripts/content/prepare-history.mjs && pnpm check && astro build",
     "preview": "astro preview",
     "check": "pnpm check:config && pnpm check:types && biome check . && pnpm check:astro && pnpm check:boundaries",
     "format": "biome format --write . && prettier --write \"src/**/*.astro\"",

--- a/scripts/content/prepare-history.mjs
+++ b/scripts/content/prepare-history.mjs
@@ -1,0 +1,17 @@
+import { execFileSync } from "node:child_process";
+
+const git = (...args) => execFileSync("git", args, { encoding: "utf8", timeout: 30_000 }).trim();
+const { VERCEL_GIT_PROVIDER: provider, VERCEL_GIT_REPO_OWNER: owner, VERCEL_GIT_REPO_SLUG: repo } = process.env;
+
+// Some deployment checkouts include Git objects without an origin remote.
+if (provider === "github" && owner && repo && !git("remote").split("\n").includes("origin")) {
+  git("remote", "add", "origin", `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}.git`);
+}
+
+// Hosting providers may supply only recent commits. Attribution needs the first.
+if (git("rev-parse", "--is-shallow-repository") === "true") {
+  execFileSync("git", ["fetch", "--unshallow", "--no-tags", "origin", git("rev-parse", "HEAD")], {
+    stdio: "inherit",
+    timeout: 120_000
+  });
+}

--- a/src/content/philes/volume-0/NETGEAR-EXS27-0.phile
+++ b/src/content/philes/volume-0/NETGEAR-EXS27-0.phile
@@ -1,7 +1,6 @@
 ---
 title: "Let's Decrypt NETGEAR EXS27 NGR Firmware V1.0.1.34!"
 date: 2026-05-27
-author: "CuB3y0nd"
 order: 0
 redacted: false
 ---

--- a/src/content/philes/volume-1/IoT/RCE-Sapido_RB-1732.phile
+++ b/src/content/philes/volume-1/IoT/RCE-Sapido_RB-1732.phile
@@ -1,7 +1,6 @@
 ---
 title: "Sapido RB-1732 路由器 RCE 漏洞"
 date: 2025-11-15
-author: "CuB3y0nd"
 lang: zh
 order: 1
 ---

--- a/src/content/philes/volume-1/cs-notes/CSAPP.phile
+++ b/src/content/philes/volume-1/cs-notes/CSAPP.phile
@@ -1,7 +1,6 @@
 ---
 title: "The CSAPP Notebook"
 date: 2025-07-16
-author: "CuB3y0nd"
 lang: zh
 order: 4
 ---

--- a/src/content/philes/volume-1/cs-notes/Cross-ISAs.phile
+++ b/src/content/philes/volume-1/cs-notes/Cross-ISAs.phile
@@ -1,7 +1,6 @@
 ---
 title: "The Cross-ISAs Notebook"
 date: 2026-01-07
-author: "CuB3y0nd"
 lang: en
 order: 1
 ---

--- a/src/content/philes/volume-1/divination/梅花易数.phile
+++ b/src/content/philes/volume-1/divination/梅花易数.phile
@@ -1,7 +1,6 @@
 ---
 title: "梅花易数札记"
 date: 2026-01-18
-author: "CuB3y0nd"
 lang: zh
 order: 3
 ---

--- a/src/content/philes/volume-1/fuzz/LibTIFF-CVE-2016-9297.phile
+++ b/src/content/philes/volume-1/fuzz/LibTIFF-CVE-2016-9297.phile
@@ -1,7 +1,6 @@
 ---
 title: "CVE-2016-9297: LibTIFF"
 date: 2026-03-06
-author: "CuB3y0nd"
 lang: zh
 order: 13
 ---

--- a/src/content/philes/volume-1/fuzz/TCPdump-CVE-2017-13028.phile
+++ b/src/content/philes/volume-1/fuzz/TCPdump-CVE-2017-13028.phile
@@ -1,7 +1,6 @@
 ---
 title: "CVE-2017-13028: TCPdump"
 date: 2026-03-02
-author: "CuB3y0nd"
 lang: zh
 order: 12
 ---

--- a/src/content/philes/volume-1/fuzz/Xpdf-CVE-2019-13288.phile
+++ b/src/content/philes/volume-1/fuzz/Xpdf-CVE-2019-13288.phile
@@ -1,7 +1,6 @@
 ---
 title: "CVE-2019-13288: Xpdf"
 date: 2026-02-10
-author: "CuB3y0nd"
 lang: zh
 order: 10
 ---

--- a/src/content/philes/volume-1/fuzz/aflplusplus.phile
+++ b/src/content/philes/volume-1/fuzz/aflplusplus.phile
@@ -1,7 +1,6 @@
 ---
 title: "The Fuzzy Notebook"
 date: 2026-02-07
-author: "CuB3y0nd"
 lang: zh
 order: 9
 ---

--- a/src/content/philes/volume-1/fuzz/libexif.phile
+++ b/src/content/philes/volume-1/fuzz/libexif.phile
@@ -1,7 +1,6 @@
 ---
 title: "Fuzz two legacy CVEs in libexif"
 date: 2026-02-24
-author: "CuB3y0nd"
 lang: zh
 order: 11
 ---

--- a/src/content/philes/volume-1/fuzz/libxml2-CVE-2017-9048.phile
+++ b/src/content/philes/volume-1/fuzz/libxml2-CVE-2017-9048.phile
@@ -1,7 +1,6 @@
 ---
 title: "CVE-2017-9048: libxml2"
 date: 2026-03-09
-author: "CuB3y0nd"
 lang: zh
 order: 14
 ---

--- a/src/content/philes/volume-1/linux/archlinux-configure-note.phile
+++ b/src/content/philes/volume-1/linux/archlinux-configure-note.phile
@@ -1,7 +1,6 @@
 ---
 title: "Arch Linux + Bspwm 配置小记"
 date: 2023-07-29
-author: "CuB3y0nd"
 lang: zh
 order: 0
 ---

--- a/src/content/philes/volume-1/mathematics/calculus-notes.phile
+++ b/src/content/philes/volume-1/mathematics/calculus-notes.phile
@@ -1,7 +1,6 @@
 ---
 title: "微积分笔记"
 date: 2024-03-31
-author: "CuB3y0nd"
 lang: zh
 order: 2
 ---

--- a/src/content/philes/volume-1/my-cves/eza-cve-report.phile
+++ b/src/content/philes/volume-1/my-cves/eza-cve-report.phile
@@ -1,7 +1,6 @@
 ---
 title: "CVE-2024-25817: eza"
 date: 2024-02-07
-author: "CuB3y0nd"
 lang: en
 order: 1
 ---

--- a/src/content/philes/volume-1/programming-language/C.phile
+++ b/src/content/philes/volume-1/programming-language/C.phile
@@ -1,7 +1,6 @@
 ---
 title: "The C Notebook"
 date: 2025-07-17
-author: "CuB3y0nd"
 lang: zh
 order: 5
 ---

--- a/src/content/philes/volume-1/projects/dynabox.phile
+++ b/src/content/philes/volume-1/projects/dynabox.phile
@@ -1,7 +1,6 @@
 ---
 title: "Dynabox: 跨平台 glibc 编译，调试相关问题的统一解决方案"
 date: 2025-08-31
-author: "CuB3y0nd"
 lang: zh
 order: 1
 ---

--- a/src/content/philes/volume-1/projects/exordium-operation-system.phile
+++ b/src/content/philes/volume-1/projects/exordium-operation-system.phile
@@ -1,7 +1,6 @@
 ---
 title: "Exordium Operating System Development Notes"
 date: 2025-03-09
-author: "CuB3y0nd"
 lang: zh
 order: 2
 ---

--- a/src/content/philes/volume-1/pwn-notes/angr.phile
+++ b/src/content/philes/volume-1/pwn-notes/angr.phile
@@ -1,7 +1,6 @@
 ---
 title: "分岔的森林：angr 符号执行札记"
 date: 2025-10-01
-author: "CuB3y0nd"
 lang: zh
 order: 0
 ---

--- a/src/content/philes/volume-1/pwn-notes/catch-handler-oriented-programming-notes.phile
+++ b/src/content/philes/volume-1/pwn-notes/catch-handler-oriented-programming-notes.phile
@@ -1,7 +1,6 @@
 ---
 title: "CHOP Suey: 端上异常处理的攻击盛宴"
 date: 2025-09-23
-author: "CuB3y0nd"
 lang: zh
 order: 12
 ---

--- a/src/content/philes/volume-1/pwn-notes/glibc-heap-allocation-analysis.phile
+++ b/src/content/philes/volume-1/pwn-notes/glibc-heap-allocation-analysis.phile
@@ -1,7 +1,6 @@
 ---
 title: "GLIBC Ptmalloc2 Dynamic Allocator Source Code Analysis"
 date: 2025-09-02
-author: "CuB3y0nd"
 lang: zh
 order: 2
 ---

--- a/src/content/philes/volume-1/pwn-notes/intel-cet-bypass.phile
+++ b/src/content/philes/volume-1/pwn-notes/intel-cet-bypass.phile
@@ -1,7 +1,6 @@
 ---
 title: "Intel Control-flow Enforcement Technology Bypass"
 date: 2026-01-26
-author: "CuB3y0nd"
 lang: zh
 order: 6
 ---

--- a/src/content/philes/volume-1/pwn-notes/labyrinth-of-houses.phile
+++ b/src/content/philes/volume-1/pwn-notes/labyrinth-of-houses.phile
@@ -1,7 +1,6 @@
 ---
 title: "屋宇之术：Labyrinth of Houses"
 date: 2025-10-04
-author: "CuB3y0nd"
 lang: zh
 order: 1
 ---

--- a/src/content/philes/volume-1/pwn-notes/pwn-trick-notes.phile
+++ b/src/content/philes/volume-1/pwn-notes/pwn-trick-notes.phile
@@ -1,7 +1,6 @@
 ---
 title: "Beyond Basics: The Dark Arts of Binary Exploitation"
 date: 2025-02-01
-author: "CuB3y0nd"
 lang: zh
 order: 0
 ---

--- a/src/content/philes/volume-1/pwn-notes/ret2gets.phile
+++ b/src/content/philes/volume-1/pwn-notes/ret2gets.phile
@@ -1,7 +1,6 @@
 ---
 title: "无 gadgets 也能翻盘：ret2gets 能否成为核武器？"
 date: 2025-09-26
-author: "CuB3y0nd"
 lang: zh
 order: 13
 ---

--- a/src/content/philes/volume-1/write-ups/0xL4ugh-CTF-v5.phile
+++ b/src/content/philes/volume-1/write-ups/0xL4ugh-CTF-v5.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: 0xL4ugh CTF v5"
 date: 2026-01-24
-author: "CuB3y0nd"
 lang: en
 order: 5
 ---

--- a/src/content/philes/volume-1/write-ups/2024-羊城杯.phile
+++ b/src/content/philes/volume-1/write-ups/2024-羊城杯.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: 2024「羊城杯」粤港澳大湾区网络安全大赛"
 date: 2025-09-22
-author: "CuB3y0nd"
 lang: zh
 order: 11
 ---

--- a/src/content/philes/volume-1/write-ups/2025-宁波市第八届网络安全大赛决赛.phile
+++ b/src/content/philes/volume-1/write-ups/2025-宁波市第八届网络安全大赛决赛.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: 2025 宁波市第八届网络安全大赛决赛"
 date: 2025-09-17
-author: "CuB3y0nd"
 lang: zh
 order: 6
 ---

--- a/src/content/philes/volume-1/write-ups/2025-强网杯-S9.phile
+++ b/src/content/philes/volume-1/write-ups/2025-强网杯-S9.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: 第九届「强网杯」全国网络安全挑战赛"
 date: 2025-10-19
-author: "CuB3y0nd"
 lang: zh
 order: 5
 ---

--- a/src/content/philes/volume-1/write-ups/2025-江苏省第七届大学生网络空间安全知识技能大赛预赛.phile
+++ b/src/content/philes/volume-1/write-ups/2025-江苏省第七届大学生网络空间安全知识技能大赛预赛.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: 2025 年江苏省第七届大学生网络空间安全知识技能大赛预赛"
 date: 2025-09-21
-author: "CuB3y0nd"
 lang: zh
 order: 10
 ---

--- a/src/content/philes/volume-1/write-ups/2025-第八届强网拟态.phile
+++ b/src/content/philes/volume-1/write-ups/2025-第八届强网拟态.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: 第八届「强网」拟态防御国际精英挑战赛-线上预选赛"
 date: 2025-10-25
-author: "CuB3y0nd"
 lang: zh
 order: 6
 ---

--- a/src/content/philes/volume-1/write-ups/2025-羊城杯.phile
+++ b/src/content/philes/volume-1/write-ups/2025-羊城杯.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: 2025 年「羊城杯」网络安全大赛初赛 [本科院校组]"
 date: 2025-10-11
-author: "CuB3y0nd"
 lang: zh
 order: 3
 ---

--- a/src/content/philes/volume-1/write-ups/BlackHat-MEA-CTF-Final-2025.phile
+++ b/src/content/philes/volume-1/write-ups/BlackHat-MEA-CTF-Final-2025.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: BlackHat MEA CTF Final 2025"
 date: 2025-12-02
-author: "CuB3y0nd"
 lang: zh
 order: 3
 ---

--- a/src/content/philes/volume-1/write-ups/ImaginaryCTF-2025.phile
+++ b/src/content/philes/volume-1/write-ups/ImaginaryCTF-2025.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: ImaginaryCTF 2025"
 date: 2025-09-19
-author: "CuB3y0nd"
 lang: zh
 order: 8
 ---

--- a/src/content/philes/volume-1/write-ups/Securinets-CTF-Quals-2025.phile
+++ b/src/content/philes/volume-1/write-ups/Securinets-CTF-Quals-2025.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Securinets CTF Quals 2025"
 date: 2025-10-04
-author: "CuB3y0nd"
 lang: zh
 order: 2
 ---

--- a/src/content/philes/volume-1/write-ups/buuctf.phile
+++ b/src/content/philes/volume-1/write-ups/buuctf.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: BUUCTF"
 date: 2025-07-05
-author: "CuB3y0nd"
 lang: zh
 order: 3
 ---

--- a/src/content/philes/volume-1/write-ups/csaw-25-quals.phile
+++ b/src/content/philes/volume-1/write-ups/csaw-25-quals.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: CSAW'25 CTF Qualification Round"
 date: 2025-09-13
-author: "CuB3y0nd"
 lang: zh
 order: 5
 ---

--- a/src/content/philes/volume-1/write-ups/fengshui.phile
+++ b/src/content/philes/volume-1/write-ups/fengshui.phile
@@ -1,7 +1,6 @@
 ---
 title: "此地不宜调试"
 date: 2026-01-19
-author: "CuB3y0nd"
 lang: zh
 order: 4
 ---

--- a/src/content/philes/volume-1/write-ups/hackthebox-pwn-challenges.phile
+++ b/src/content/philes/volume-1/write-ups/hackthebox-pwn-challenges.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: HackTheBox"
 date: 2025-07-24
-author: "CuB3y0nd"
 lang: zh
 order: 6
 ---

--- a/src/content/philes/volume-1/write-ups/idekCTF-2025.phile
+++ b/src/content/philes/volume-1/write-ups/idekCTF-2025.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: idekCTF 2025"
 date: 2025-09-19
-author: "CuB3y0nd"
 lang: zh
 order: 7
 ---

--- a/src/content/philes/volume-1/write-ups/nepctf-2025.phile
+++ b/src/content/philes/volume-1/write-ups/nepctf-2025.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: NepCTF 2025"
 date: 2025-09-20
-author: "CuB3y0nd"
 lang: zh
 order: 9
 ---

--- a/src/content/philes/volume-1/write-ups/nightmare-series.phile
+++ b/src/content/philes/volume-1/write-ups/nightmare-series.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Nightmare series"
 date: 2024-07-24
-author: "CuB3y0nd"
 lang: zh
 order: 3
 ---

--- a/src/content/philes/volume-1/write-ups/nullcon-ctf-2025.phile
+++ b/src/content/philes/volume-1/write-ups/nullcon-ctf-2025.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Nullcon Berlin HackIM 2025 CTF"
 date: 2025-09-07
-author: "CuB3y0nd"
 lang: zh
 order: 3
 ---

--- a/src/content/philes/volume-1/write-ups/pwnable-tw.phile
+++ b/src/content/philes/volume-1/write-ups/pwnable-tw.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Pwnable.tw"
 date: 2026-02-06
-author: "CuB3y0nd"
 lang: zh
 order: 8
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-arm-rop.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-arm-rop.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: ARM Architecture (ARM64 ROP) series"
 date: 2026-01-11
-author: "CuB3y0nd"
 lang: zh
 order: 2
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-dynamic-allocator-exploitation.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-dynamic-allocator-exploitation.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Software Exploitation (Dynamic Allocator Exploitation) series (Completed)"
 date: 2025-10-17
-author: "CuB3y0nd"
 lang: zh
 order: 4
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-dynamic-allocator-misuse.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-dynamic-allocator-misuse.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Program Security (Dynamic Allocator Misuse) series (Completed)"
 date: 2025-09-08
-author: "CuB3y0nd"
 lang: zh
 order: 4
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-file-struct-exploits.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-file-struct-exploits.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Software Exploitation (File Struct Exploits) series (Completed)"
 date: 2025-11-03
-author: "CuB3y0nd"
 lang: zh
 order: 0
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-format-string-exploits.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-format-string-exploits.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Software Exploitation (Format String Exploits) series"
 date: 2025-01-29
-author: "CuB3y0nd"
 lang: zh
 order: 9
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-kernel-security.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-kernel-security.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: System Security (Kernel Security) series (Completed)"
 date: 2025-12-19
-author: "CuB3y0nd"
 lang: zh
 order: 4
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-memory-errors.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-memory-errors.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Program Security (Memory Errors) series (Completed)"
 date: 2024-12-05
-author: "CuB3y0nd"
 lang: zh
 order: 4
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-memory-mastery.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-memory-mastery.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Software Exploitation (Exploitation Primitives) series (Completed)"
 date: 2025-11-21
-author: "CuB3y0nd"
 lang: zh
 order: 2
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-microarchitecture-exploitation.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-microarchitecture-exploitation.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: System Security (Microarchitecture Exploitation) series"
 date: 2026-01-30
-author: "CuB3y0nd"
 lang: zh
 order: 7
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-program-exploitation.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-program-exploitation.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Program Security (Program Exploitation) series (Completed)"
 date: 2024-12-29
-author: "CuB3y0nd"
 lang: zh
 order: 6
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-return-oriented-programming.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-return-oriented-programming.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Program Security (Return Oriented Programming) series (Completed)"
 date: 2025-01-19
-author: "CuB3y0nd"
 lang: zh
 order: 8
 ---

--- a/src/content/philes/volume-1/write-ups/pwncollege-shellcode-injection.phile
+++ b/src/content/philes/volume-1/write-ups/pwncollege-shellcode-injection.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Program Security (Shellcode Injection) series (Completed)"
 date: 2024-12-24
-author: "CuB3y0nd"
 lang: zh
 order: 5
 ---

--- a/src/content/philes/volume-1/write-ups/rop-emporium-series.phile
+++ b/src/content/philes/volume-1/write-ups/rop-emporium-series.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: ROP Emporium series"
 date: 2025-02-01
-author: "CuB3y0nd"
 lang: zh
 order: 1
 ---

--- a/src/content/philes/volume-1/write-ups/sunshinectf-2025.phile
+++ b/src/content/philes/volume-1/write-ups/sunshinectf-2025.phile
@@ -1,7 +1,6 @@
 ---
 title: "Write-ups: Sunshine CTF 2025"
 date: 2025-09-29
-author: "CuB3y0nd"
 lang: zh
 order: 14
 ---

--- a/src/content/philes/volume-2/year-end-wrap-ups/2024-wrap-up.phile
+++ b/src/content/philes/volume-2/year-end-wrap-ups/2024-wrap-up.phile
@@ -1,7 +1,6 @@
 ---
 title: "2024 年终总结"
 date: 2025-01-01
-author: "CuB3y0nd"
 lang: zh
 ---
 

--- a/src/content/philes/volume-2/year-end-wrap-ups/2025-wrap-up.phile
+++ b/src/content/philes/volume-2/year-end-wrap-ups/2025-wrap-up.phile
@@ -1,7 +1,6 @@
 ---
 title: "2025 年终总结"
 date: 2026-01-01
-author: "CuB3y0nd"
 lang: zh
 ---
 

--- a/src/content/philes/volume-3/experiments/ansi-ink-phile.phile
+++ b/src/content/philes/volume-3/experiments/ansi-ink-phile.phile
@@ -1,7 +1,6 @@
 ---
 title: "ANSI Ink for Philes"
 date: 2026-05-29
-author: "CuB3y0nd"
 lang: en
 ---
 

--- a/src/content/philes/volume-3/experiments/inspect-field-notes.phile
+++ b/src/content/philes/volume-3/experiments/inspect-field-notes.phile
@@ -1,7 +1,6 @@
 ---
 title: "Inspect: Read the Bits"
 date: 2026-09-09
-author: "CuB3y0nd"
 lang: en
 slug: inspect-field-notes
 ---

--- a/src/features/philes/content/schema.ts
+++ b/src/features/philes/content/schema.ts
@@ -1,11 +1,10 @@
 import { z } from "astro/zod";
 
-export const requiredPhileFields = ["title", "date", "author"] as const;
+export const requiredPhileFields = ["title", "date"] as const;
 
 export const phileSchema = z.object({
   title: z.string().min(1),
   date: z.date(),
-  author: z.string().min(1),
   lang: z.enum(["en", "zh"]).default("en"),
   slug: z.string().optional(),
   order: z.number().int().nonnegative().optional(),

--- a/src/features/philes/data/credits.ts
+++ b/src/features/philes/data/credits.ts
@@ -1,0 +1,40 @@
+import type { PhileCredit } from "../model";
+import { type GitPerson, githubRepository, readGitHistory } from "./git-history";
+import { resolveGitPerson } from "./github";
+
+export async function getPhileCredits(files: readonly string[]): Promise<Map<string, readonly PhileCredit[]>> {
+  const [history, repository] = await Promise.all([readGitHistory(files), githubRepository()]);
+  const identities = new Map<string, GitPerson>();
+  for (const people of history.values()) {
+    for (const person of people) {
+      const key = person.email.toLowerCase();
+      const existing = identities.get(key);
+      if (!existing || (!existing.primary && person.primary)) identities.set(key, person);
+    }
+  }
+  const pending = identities.entries();
+  const profiles = new Map<string, PhileCredit>();
+  const worker = async () => {
+    for (const [email, person] of pending) {
+      profiles.set(email, await resolveGitPerson(person, repository));
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(4, identities.size) }, worker));
+  const credits = new Map<string, readonly PhileCredit[]>();
+  for (const [file, people] of history) {
+    const resolved: PhileCredit[] = [];
+    const seen = new Set<string>();
+    for (const person of people) {
+      const email = person.email.toLowerCase();
+      const profile = profiles.get(email);
+      if (!profile) continue;
+      const key = profile.login?.toLowerCase() ?? email;
+      if (!seen.has(key)) {
+        seen.add(key);
+        resolved.push(profile);
+      }
+    }
+    credits.set(file, resolved);
+  }
+  return credits;
+}

--- a/src/features/philes/data/git-history.ts
+++ b/src/features/philes/data/git-history.ts
@@ -1,0 +1,96 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+export type GitPerson = { name: string; email: string; commit: string; primary: boolean };
+type HistoryCache = { head: string; files: Map<string, Promise<readonly GitPerson[]>> };
+const repositories = new Map<string, HistoryCache>();
+
+async function git(root: string, args: string[]): Promise<string> {
+  const { stdout } = await exec("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+    timeout: 30_000
+  });
+  return stdout;
+}
+
+/** Follow each file back to its creation. The first person is its author. */
+export async function readGitHistory(files: readonly string[], root = process.cwd()) {
+  root = path.resolve(root);
+  const [head, shallow] = (await git(root, ["rev-parse", "HEAD", "--is-shallow-repository"])).trim().split("\n");
+  if (!head || shallow !== "false") {
+    throw new Error("Automatic article credits need complete Git history. Run git fetch --unshallow first.");
+  }
+  let cache = repositories.get(root);
+  if (!cache || cache.head !== head) {
+    cache = { head, files: new Map() };
+    repositories.set(root, cache);
+  }
+
+  const uniqueFiles = new Set(files);
+  const pending = uniqueFiles.values();
+  const result = new Map<string, readonly GitPerson[]>();
+  const worker = async () => {
+    for (const file of pending) {
+      let history = cache.files.get(file);
+      if (!history) {
+        history = historyForFile(root, head, file);
+        cache.files.set(file, history);
+      }
+      try {
+        result.set(file, await history);
+      } catch (error) {
+        cache.files.delete(file);
+        throw error;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(4, uniqueFiles.size) }, worker));
+  return result;
+}
+
+async function historyForFile(root: string, head: string, file: string): Promise<readonly GitPerson[]> {
+  const output = await git(root, [
+    "log",
+    "--follow",
+    "--no-merges",
+    "--topo-order",
+    "--no-show-signature",
+    "--format=%x1e%H%x00%aN%x00%aE%x00%(trailers:key=Co-authored-by,valueonly,unfold,separator=%x1f)",
+    head,
+    "--",
+    file
+  ]);
+  const people = new Map<string, GitPerson>();
+  const append = (person: GitPerson) => {
+    const key = person.email.toLowerCase();
+    const existing = people.get(key);
+    // A later authored commit can identify a coauthor without changing their order.
+    if (!existing || (!existing.primary && person.primary)) people.set(key, person);
+  };
+  // --reverse and --follow do not reliably trace older paths together.
+  for (const record of output.split("\x1e").filter(Boolean).reverse()) {
+    const [commit, name, email, trailers] = record.trim().split("\0");
+    if (!commit || !name || !email) continue;
+    append({ name, email, commit, primary: true });
+    for (const trailer of trailers?.split("\x1f") ?? []) {
+      const match = /^(.*?)\s*<([^<>]+)>$/.exec(trailer.trim());
+      if (match?.[1] && match[2]) append({ name: match[1].trim(), email: match[2], commit, primary: false });
+    }
+  }
+  return [...people.values()];
+}
+
+export async function githubRepository(root = process.cwd()): Promise<string | undefined> {
+  try {
+    const remote = (await git(root, ["remote", "get-url", "origin"])).trim();
+    const match = /^(?:git@github\.com:|(?:https:\/\/|ssh:\/\/(?:git@)?)github\.com\/)([^/]+\/[^/]+?)(?:\.git)?$/.exec(
+      remote
+    );
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+}

--- a/src/features/philes/data/github.ts
+++ b/src/features/philes/data/github.ts
@@ -1,0 +1,84 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { PhileCredit } from "../model";
+import type { GitPerson } from "./git-history";
+
+type Cached = { value: unknown; fetchedAt: number };
+const requests = new Map<string, { until: number; value: Promise<unknown> }>();
+const lifetime = 24 * 60 * 60 * 1000;
+const cacheDirectory = path.join(process.cwd(), ".cache", "github-credits");
+
+export function githubCredit(account: { login: string; name?: string | null }): PhileCredit {
+  return {
+    login: account.login,
+    name: account.name?.replace(/\s+/g, " ").trim() || account.login,
+    href: `https://github.com/${encodeURIComponent(account.login)}`
+  };
+}
+
+export function githubLogin(email: string): string | undefined {
+  return /^(?:\d+\+)?([a-z\d](?:[a-z\d-]{0,37}[a-z\d])?)@users\.noreply\.github\.com$/i.exec(email)?.[1];
+}
+
+export async function resolveGitPerson(person: GitPerson, repository?: string): Promise<PhileCredit> {
+  let login = githubLogin(person.email);
+  if (!login && person.primary && repository) {
+    const commit = await githubJson(`repos/${repository}/commits/${person.commit}`);
+    if (isRecord(commit) && isRecord(commit.author) && typeof commit.author.login === "string") {
+      login = commit.author.login;
+    }
+  }
+  if (!login) return { name: person.name };
+
+  const account = await githubJson(`users/${encodeURIComponent(login.toLowerCase())}`);
+  return isRecord(account) &&
+    typeof account.login === "string" &&
+    (typeof account.name === "string" || account.name === null)
+    ? githubCredit({ login: account.login, name: account.name })
+    : githubCredit({ login });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function githubJson(endpoint: string): Promise<unknown> {
+  const existing = requests.get(endpoint);
+  if (existing && existing.until > Date.now()) return existing.value;
+  // Share profile requests across every article, including an offline result.
+  const request = loadJson(endpoint);
+  requests.set(endpoint, { until: Date.now() + lifetime, value: request });
+  return request;
+}
+
+async function loadJson(endpoint: string): Promise<unknown> {
+  const filename = path.join(cacheDirectory, `${encodeURIComponent(endpoint)}.json`);
+  let cached: Cached | undefined;
+  try {
+    cached = JSON.parse(await readFile(filename, "utf8"));
+    // Builds refresh profiles once, then bake them into HTML. Disk data is the
+    // offline fallback; dev requests can reuse it without hitting GitHub again.
+    if (cached && !import.meta.env?.PROD && Date.now() - cached.fetchedAt < lifetime) return cached.value;
+  } catch {
+    // A fresh checkout has no cached GitHub identities.
+  }
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2026-03-10"
+    };
+    if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    const response = await fetch(`https://api.github.com/${endpoint}`, { headers, signal: AbortSignal.timeout(4000) });
+    if (!response.ok) return cached?.value;
+    const value: unknown = await response.json();
+    try {
+      await mkdir(cacheDirectory, { recursive: true });
+      await writeFile(filename, `${JSON.stringify({ value, fetchedAt: Date.now() })}\n`);
+    } catch {
+      // A read-only cache must not discard a successful response.
+    }
+    return value;
+  } catch {
+    return cached?.value;
+  }
+}

--- a/src/features/philes/data/repository.ts
+++ b/src/features/philes/data/repository.ts
@@ -2,30 +2,32 @@ import { getCollection } from "astro:content";
 import { volumeConfig } from "@/config/server";
 import type { VolumePhileSort } from "@/config/types";
 import type { Phile } from "../model";
+import { getPhileCredits } from "./credits";
 import { routeForPhile } from "./routing";
 
-let productionPhileCache: readonly Phile[] | undefined;
+let buildPhiles: Promise<readonly Phile[]> | undefined;
 
-export async function getAllPhiles(): Promise<readonly Phile[]> {
-  if (import.meta.env.PROD && productionPhileCache) {
-    return productionPhileCache;
+export function getAllPhiles(): Promise<readonly Phile[]> {
+  // Static routes and feeds share one attribution snapshot for the whole build.
+  if (import.meta.env.PROD) {
+    buildPhiles ??= loadPhiles();
+    return buildPhiles;
   }
+  return loadPhiles();
+}
 
+async function loadPhiles(): Promise<readonly Phile[]> {
   const entries = await getCollection("philes");
+  const credits = await getPhileCredits(entries.flatMap((entry) => (entry.filePath ? [entry.filePath] : [])));
   const philes = entries.map((entry) => ({
     ...entry,
+    credits: credits.get(entry.filePath ?? "") ?? [],
     route: routeForPhile(entry)
   }));
 
   assertUniqueSlugs(philes);
 
-  const sorted = Object.freeze(philes.sort(comparePhiles));
-
-  if (import.meta.env.PROD) {
-    productionPhileCache = sorted;
-  }
-
-  return sorted;
+  return Object.freeze(philes.sort(comparePhiles));
 }
 
 function comparePhiles(left: Phile, right: Phile): number {

--- a/src/features/philes/index.ts
+++ b/src/features/philes/index.ts
@@ -1,1 +1,1 @@
-export type { Phile, PhileEntry, PhileRoute } from "./model";
+export type { Phile, PhileCredit, PhileEntry, PhileRoute } from "./model";

--- a/src/features/philes/model.ts
+++ b/src/features/philes/model.ts
@@ -12,4 +12,12 @@ export type PhileRoute = {
 
 export type Phile = PhileEntry & {
   route: PhileRoute;
+  /** The original author comes first, followed by contributors in first-commit order. */
+  credits: readonly PhileCredit[];
+};
+
+export type PhileCredit = {
+  name: string;
+  login?: string;
+  href?: string;
 };

--- a/src/features/philes/rendering/render.ts
+++ b/src/features/philes/rendering/render.ts
@@ -42,7 +42,8 @@ export function renderPhile(phile: Phile): PhileView {
 
 function renderPhileHeader(phile: Phile): PhileHeader {
   const titleLines = wrapWordsCells(phile.data.title, titleWidth);
-  const metaLines = [...titleLines, `~ ${phile.data.author}`];
+  const author = phile.credits[0];
+  const metaLines = [...titleLines, ...(author ? wrapWordsCells(`~ ${author.name}`, titleWidth) : [])];
 
   return {
     metaHtml: metaLines.map(textHtml).join("\n"),

--- a/src/features/seo/xml.ts
+++ b/src/features/seo/xml.ts
@@ -94,7 +94,7 @@ function renderRssItem(site: URL, phile: Phile): string {
       <link>${escapeXml(url)}</link>
       <guid isPermaLink="true">${escapeXml(url)}</guid>
       <pubDate>${formatRssDate(phile.data.date)}</pubDate>
-      <dc:creator>${escapeXml(phile.data.author)}</dc:creator>
+      ${phile.credits[0] ? `<dc:creator>${escapeXml(phile.credits[0].name)}</dc:creator>` : ""}
       <description>${escapeXml(phileExcerpt(phile))}</description>
     </item>`;
 }

--- a/src/features/volumes/components/Credits.astro
+++ b/src/features/volumes/components/Credits.astro
@@ -1,0 +1,53 @@
+---
+import type { Volume } from "../model";
+import { hasCreditDetails } from "../credits/presentation";
+import "../credits/styles.css";
+
+type Props = { volume: Volume };
+const { volume } = Astro.props;
+---
+
+{
+  volume.philes.map((phile, index) =>
+    hasCreditDetails(phile.credits) ? (
+      <div
+        id={`phile-credits-${index}`}
+        class="phile-credits"
+        popover="auto"
+        role="dialog"
+        aria-labelledby={`phile-credits-title-${index}`}
+        data-phile-credits
+      >
+        <span id={`phile-credits-title-${index}`} class="phile-credits-label">
+          Contributors ({phile.credits.length}):
+        </span>
+        <ol aria-label="Author, followed by contributors">
+          {phile.credits.map((person, personIndex) => (
+            <li>
+              {person.href ? (
+                <a
+                  href={person.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={`${personIndex === 0 ? "Author" : "Contributor"}${person.login ? ` · @${person.login}` : ""}`}
+                >
+                  {person.name}
+                </a>
+              ) : (
+                <span title={personIndex === 0 ? "Author" : "Contributor"}>{person.name}</span>
+              )}
+              {personIndex < phile.credits.length - 1 && ","}
+            </li>
+          ))}
+        </ol>
+      </div>
+    ) : null
+  )
+}
+
+<script>
+  import { installCredits } from "../credits/client";
+  import { afterPageLoad } from "@/shared/browser/ready";
+
+  afterPageLoad(installCredits);
+</script>

--- a/src/features/volumes/components/VolumeScreen.astro
+++ b/src/features/volumes/components/VolumeScreen.astro
@@ -1,6 +1,7 @@
 ---
 import type { Volume } from "../model";
 import { renderVolumePre } from "../rendering/render";
+import Credits from "./Credits.astro";
 import "@/shared/textmode/styles/life.css";
 
 type Props = {
@@ -14,6 +15,8 @@ const volumeHtml = renderVolumePre(volume);
 <section class="textmode-wrap volume-wrap mt-line">
   <pre class="textmode-pre volume-pre life-art" data-life-root set:html={volumeHtml} />
 </section>
+
+<Credits volume={volume} />
 
 <script>
   import { initLifeArt } from "@/shared/textmode/life/client";

--- a/src/features/volumes/credits/client.ts
+++ b/src/features/volumes/credits/client.ts
@@ -1,0 +1,54 @@
+export function installCredits(): void {
+  const popovers = document.querySelectorAll<HTMLElement>("[data-phile-credits]");
+  if (popovers.length === 0) return;
+  for (const popover of popovers) {
+    const list = popover.querySelector("ol");
+    if (!list) continue;
+    list.addEventListener(
+      "wheel",
+      (event) => {
+        if (event.ctrlKey) return;
+        // Firefox can pass a fresh wheel gesture at either edge to the page.
+        const atStart = event.deltaY < 0 && list.scrollTop <= 0;
+        const atEnd = event.deltaY > 0 && list.scrollTop + list.clientHeight >= list.scrollHeight - 1;
+        if (atStart || atEnd) event.preventDefault();
+      },
+      { passive: false }
+    );
+  }
+  let anchor: HTMLElement | undefined;
+  let panel: HTMLElement | undefined;
+
+  const position = () => {
+    if (!anchor || !panel?.matches(":popover-open")) return;
+    const target = anchor.getBoundingClientRect();
+    const bounds = panel.getBoundingClientRect();
+    const viewport = window.visualViewport;
+    const leftEdge = (viewport?.offsetLeft ?? 0) + 12;
+    const topEdge = (viewport?.offsetTop ?? 0) + 12;
+    const rightEdge = leftEdge + (viewport?.width ?? innerWidth) - 24;
+    const bottomEdge = topEdge + (viewport?.height ?? innerHeight) - 24;
+    panel.style.left = `${Math.max(leftEdge, Math.min(target.right - bounds.width, rightEdge - bounds.width))}px`;
+    panel.style.top = `${Math.max(topEdge, Math.min(target.bottom + 8, bottomEdge - bounds.height))}px`;
+  };
+  const close = () => {
+    if (panel?.matches(":popover-open")) panel.hidePopover();
+  };
+
+  document.addEventListener("click", (event) => {
+    const trigger =
+      event.target instanceof Element ? event.target.closest<HTMLButtonElement>("[data-credits-trigger]") : null;
+    if (!trigger) return;
+    const target = document.getElementById(trigger.getAttribute("popovertarget") ?? "");
+    if (!target) return;
+    event.preventDefault();
+    if (panel !== target) close();
+    panel = target;
+    anchor = trigger;
+    panel.togglePopover();
+    position();
+  });
+  window.addEventListener("resize", position, { passive: true });
+  window.addEventListener("scroll", close, { passive: true });
+  window.visualViewport?.addEventListener("resize", position, { passive: true });
+}

--- a/src/features/volumes/credits/presentation.ts
+++ b/src/features/volumes/credits/presentation.ts
@@ -1,0 +1,8 @@
+import type { PhileCredit } from "@/features/philes";
+import { cellWidth } from "@/shared/textmode";
+
+export const creditAuthorWidth = 22;
+
+export function hasCreditDetails(credits: readonly PhileCredit[]): boolean {
+  return credits.length > 1 || cellWidth(credits[0]?.name ?? "") > creditAuthorWidth;
+}

--- a/src/features/volumes/credits/styles.css
+++ b/src/features/volumes/credits/styles.css
@@ -1,0 +1,84 @@
+.credits-trigger {
+  display: inline;
+  appearance: none;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--link);
+  font: inherit;
+  line-height: inherit;
+  cursor: pointer;
+}
+
+.credits-trigger:hover,
+.credits-trigger:focus-visible {
+  color: var(--link-hover);
+  background: var(--link-hover-bg);
+  outline: none;
+  text-decoration: underline;
+}
+
+.phile-credits {
+  --credits-max-height: min(440px, calc(100dvh - 24px));
+  position: fixed;
+  inset: auto;
+  box-sizing: border-box;
+  width: max-content;
+  max-width: min(360px, calc(100vw - 24px));
+  min-width: min(180px, calc(100vw - 24px));
+  max-height: var(--credits-max-height);
+  margin: 0;
+  padding: 12px 16px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--link) 45%, var(--bg));
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--text-font);
+  font-size: 14px;
+  line-height: 1.5;
+  text-align: left;
+  box-shadow: 0 8px 24px #0007;
+  overflow-wrap: anywhere;
+}
+
+.phile-credits:popover-open {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 0.75ch;
+}
+
+.phile-credits-label {
+  flex: 0 0 auto;
+  color: color-mix(in srgb, var(--fg) 65%, var(--bg));
+}
+
+.phile-credits ol {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 0.75ch;
+  min-width: 0;
+  max-width: 100%;
+  /* Keep the label and panel padding visible even in a short viewport. */
+  max-height: calc(var(--credits-max-height) - 26px - 1.5em - 8px);
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
+  list-style: none;
+}
+
+.phile-credits ol::-webkit-scrollbar {
+  display: none;
+}
+
+.phile-credits li {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.phile-credits li > span {
+  color: var(--link);
+}

--- a/src/features/volumes/rendering/render.ts
+++ b/src/features/volumes/rendering/render.ts
@@ -1,6 +1,8 @@
 import { textmodeConfig, volumeConfig } from "@/config/server";
+import type { PhileCredit } from "@/features/philes";
 import { cellWidth, escapeHtml, link, padCells, textHtml, truncateCells } from "@/shared/textmode";
 import { lifeFrameLineHtml, lifeFrameLines } from "@/shared/textmode/life";
+import { creditAuthorWidth } from "../credits/presentation";
 import type { Volume } from "../model";
 import { volumeTitle } from "./labels";
 
@@ -23,6 +25,10 @@ function renderToc(volume: Volume): string {
   const entryLabelWidth = Math.max(
     ...volume.philes.map((phile, index) => cellWidth(entryLabel(volume, index, phile.data.title, phile.data.date)))
   );
+  const badgeWidth = Math.max(
+    0,
+    ...volume.philes.map((phile) => (phile.credits.length > 1 ? String(phile.credits.length - 1).length + 4 : 0))
+  );
   const lines = [
     ...lifeLines.slice(0, 14).map((_, row) => `${" ".repeat(artIndent)}${lifeFrameLineHtml(row)}`),
     `┌${"─".repeat(artIndent - 1)}${lifeFrameLineHtml(14)}`,
@@ -36,8 +42,9 @@ function renderToc(volume: Volume): string {
         phile.data.title,
         phile.data.date,
         phile.route.href,
-        phile.data.author,
-        entryLabelWidth
+        phile.credits,
+        entryLabelWidth,
+        badgeWidth
       )
     ),
     frameLine(""),
@@ -53,21 +60,29 @@ function renderTocLine(
   title: string,
   date: Date,
   href: string,
-  author: string,
-  entryLabelWidth: number
+  credits: readonly PhileCredit[],
+  entryLabelWidth: number,
+  badgeWidth: number
 ): string {
   const config = volumeConfig(volume.number);
   const label = entryLabel(volume, index, title, date);
   const prefix = `${padCells(label, entryLabelWidth)}  `;
   const entryTitle = config.entryLabel === "year" ? title.replace(/^\d{4}\s+/, "") : title;
-  const tail = ` ${author}`;
+  const author = credits[0]?.name ?? "";
+  const displayAuthor = truncateCells(author, creditAuthorWidth);
+  const count = credits.length > 1 ? ` [+${credits.length - 1}]` : "";
+  const tail = ` ${displayAuthor}${padCells(count, badgeWidth)}`;
+  const trigger = (label: string) =>
+    `<button type="button" class="credits-trigger" data-credits-trigger popovertarget="phile-credits-${index}" aria-label="${escapeHtml(`Author and contributors: ${title}`)}">${textHtml(label)}</button>`;
+  const authorHtml = displayAuthor !== author ? trigger(displayAuthor) : textHtml(displayAuthor);
+  const tailHtml = ` ${authorHtml}${count ? ` ${trigger(count.trimStart())}` : ""}${" ".repeat(badgeWidth - cellWidth(count))}`;
   const titleWidth = Math.max(1, tocInnerWidth - cellWidth(prefix) - cellWidth(tail) - 6);
   const displayTitle = truncateCells(entryTitle, titleWidth);
   const titleLink = link(href, displayTitle);
   const visibleLeft = `${prefix}${displayTitle}`;
   const dots = ".".repeat(Math.max(3, tocInnerWidth - cellWidth(visibleLeft) - cellWidth(tail) - 3));
 
-  return `│ ${escapeHtml(prefix)}${titleLink} ${dots}${textHtml(tail)} │`;
+  return `│ ${escapeHtml(prefix)}${titleLink} ${dots}${tailHtml} │`;
 }
 
 function entryLabel(volume: Volume, index: number, title: string, date: Date): string {

--- a/tests/content/credits.test.ts
+++ b/tests/content/credits.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { readGitHistory } from "../../src/features/philes/data/git-history";
+import { githubCredit, githubLogin } from "../../src/features/philes/data/github";
+
+test("article history preserves the creator across renames, deduplicates revisions, and includes coauthors", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "entropic-history-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", root, ...args], { encoding: "utf8" });
+  const commit = (name: string, email: string, message: string) => {
+    git("add", ".");
+    git("-c", "commit.gpgsign=false", "commit", "--author", `${name} <${email}>`, "-m", message);
+  };
+  try {
+    git("init", "-q");
+    git("config", "user.name", "Merger");
+    git("config", "user.email", "merger@example.test");
+    await writeFile(path.join(root, "before.phile"), "one\ntwo\nthree\nfour\n");
+    commit("Original", "original@example.test", "First article");
+    await rename(path.join(root, "before.phile"), path.join(root, "after.phile"));
+    commit("Original", "original@example.test", "Rename article");
+    await writeFile(path.join(root, "after.phile"), "one\ntwo\nthree\nfour\nfive\n");
+    commit("Editor", "editor@example.test", "Revise article\n\nCo-authored-by: Helper <helper@example.test>");
+    const names = async () => (await readGitHistory(["after.phile"], root)).get("after.phile")?.map((p) => p.name);
+    assert.deepEqual(await names(), ["Original", "Editor", "Helper"]);
+    await writeFile(path.join(root, "after.phile"), "one\ntwo\nthree\nfour\nfive\nsix\n");
+    commit("Original", "original@example.test", "Author revision");
+    assert.deepEqual(await names(), ["Original", "Editor", "Helper"]);
+    await writeFile(path.join(root, "after.phile"), "one\ntwo\nthree\nfour\nfive\nsix\nseven\n");
+    commit("Later", "later@example.test", "Later revision");
+    assert.deepEqual(await names(), ["Original", "Editor", "Helper", "Later"]);
+    await writeFile(path.join(root, "after.phile"), "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\n");
+    commit("Helper", "helper@example.test", "A coauthor's own revision");
+    const people = (await readGitHistory(["after.phile"], root)).get("after.phile");
+    assert.deepEqual(
+      people?.map((person) => person.name),
+      ["Original", "Editor", "Helper", "Later"]
+    );
+    assert.equal(people?.[2]?.primary, true);
+    assert.equal(people?.[2]?.commit, git("rev-parse", "HEAD").trim());
+    assert.deepEqual((await readGitHistory(["uncommitted.phile"], root)).get("uncommitted.phile"), []);
+    const shallow = path.join(root, "shallow");
+    git("clone", "--quiet", "--depth=1", pathToFileURL(root).href, shallow);
+    await assert.rejects(readGitHistory(["after.phile"], shallow), /complete Git history/);
+    execFileSync(
+      process.execPath,
+      [fileURLToPath(new URL("../../scripts/content/prepare-history.mjs", import.meta.url))],
+      {
+        cwd: shallow,
+        stdio: "pipe"
+      }
+    );
+    assert.deepEqual(
+      (await readGitHistory(["after.phile"], shallow)).get("after.phile")?.map((p) => p.name),
+      ["Original", "Editor", "Helper", "Later"]
+    );
+    const vercel = path.join(root, "vercel");
+    git("clone", "--quiet", "--depth=1", pathToFileURL(root).href, vercel);
+    const deploymentGit = (...args: string[]) => execFileSync("git", ["-C", vercel, ...args], { encoding: "utf8" });
+    const head = deploymentGit("rev-parse", "HEAD");
+    deploymentGit("remote", "remove", "origin");
+    deploymentGit("config", `url.${pathToFileURL(root).href}.insteadOf`, "https://github.com/example/site.git");
+    execFileSync(
+      process.execPath,
+      [fileURLToPath(new URL("../../scripts/content/prepare-history.mjs", import.meta.url))],
+      {
+        cwd: vercel,
+        stdio: "pipe",
+        env: {
+          ...process.env,
+          VERCEL_GIT_PROVIDER: "github",
+          VERCEL_GIT_REPO_OWNER: "example",
+          VERCEL_GIT_REPO_SLUG: "site"
+        }
+      }
+    );
+    assert.equal(deploymentGit("rev-parse", "HEAD"), head);
+    assert.deepEqual(
+      (await readGitHistory(["after.phile"], vercel)).get("after.phile")?.map((p) => p.name),
+      ["Original", "Editor", "Helper", "Later"]
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("GitHub identities use nicknames and fall back to logins without guessing from ordinary email addresses", () => {
+  assert.equal(githubLogin("117096890+pmc4@users.noreply.github.com"), "pmc4");
+  assert.equal(githubLogin("pmc4@users.noreply.github.com"), "pmc4");
+  assert.equal(githubLogin("pmc4@example.test"), undefined);
+  assert.equal(githubCredit({ login: "pmc4", name: "  A\nNickname  " }).name, "A Nickname");
+  assert.equal(githubCredit({ login: "pmc4", name: null }).name, "pmc4");
+  assert.equal(githubCredit({ login: "pmc4", name: "  " }).name, "pmc4");
+});

--- a/tests/content/render.test.ts
+++ b/tests/content/render.test.ts
@@ -10,9 +10,9 @@ function phile(body: string, redacted = false): Phile {
     id: "volume-0/example.phile",
     collection: "philes" as const,
     body,
-    data: { title: "Example", author: "Author", date: new Date("2026-01-01"), lang: "en" as const, redacted }
+    data: { title: "Example", date: new Date("2026-01-01"), lang: "en" as const, redacted }
   };
-  return { ...entry, route: routeForPhile(entry) };
+  return { ...entry, route: routeForPhile(entry), credits: [{ name: "Author" }] };
 }
 
 test("frontmatter accepts BOM, CRLF, and a closing delimiter at EOF", () => {

--- a/tests/content/routes.test.ts
+++ b/tests/content/routes.test.ts
@@ -7,7 +7,7 @@ function entry(slug?: string, id = "volume-0/example.phile"): PhileEntry {
   return {
     id,
     collection: "philes",
-    data: { title: "Example", author: "Author", date: new Date("2026-01-01"), lang: "en", redacted: false, slug }
+    data: { title: "Example", date: new Date("2026-01-01"), lang: "en", redacted: false, slug }
   };
 }
 

--- a/tests/seo/xml.test.ts
+++ b/tests/seo/xml.test.ts
@@ -3,14 +3,14 @@ import { test } from "node:test";
 import type { Phile } from "../../src/features/philes";
 import { phileExcerpt, renderRss, renderSitemap } from "../../src/features/seo";
 
-function phile(body: string, overrides: Partial<Phile["data"]> = {}): Phile {
+function phile(body: string, overrides: Partial<Phile["data"]> = {}, author = "Author"): Phile {
   return {
     id: "volume-0/example.phile",
     collection: "philes",
     body,
+    credits: [{ name: author }],
     data: {
       title: "Example",
-      author: "Author",
       date: new Date("2026-01-01"),
       lang: "en",
       redacted: false,
@@ -30,7 +30,7 @@ const site = new URL("https://example.com");
 const feed = (philes: readonly Phile[]) => renderRss({ site, title: "A & B", description: "Notes", philes });
 
 test("RSS represents author names with Dublin Core and preserves chronological order", () => {
-  const older = phile("Older", { title: "Older", author: "A <B> & C" });
+  const older = phile("Older", { title: "Older" }, "A <B> & C");
   const newer = phile("Newer", { title: "Newer", date: new Date("2026-02-02") });
   const input = [older, newer];
   const xml = feed(input);


### PR DESCRIPTION
## Summary

Manually maintained author fields leave article revisions uncredited. Derive the original author and subsequent contributors from Git history, following renames and coauthored commits. Prefer GitHub nicknames and reuse one build-time attribution snapshot in volume listings, article headers, and RSS.

Volume listings keep the author and a compact additional-contributor count. The detail panel starts with `Contributors (N):`, puts the author first, wraps whole names where possible, and scrolls long lists without a visible scrollbar. Panels are generated only for entries that need them; Volume 1 HTML drops from 59,220 to 36,043 bytes compared with the initial contributor implementation.

## Scope

- [x] User-facing behavior
- [x] Content
- [x] Documentation
- [x] Tooling or automation
- [x] Build, CI, or deployment
- [x] Performance or maintenance

## Verification

- `pnpm install --frozen-lockfile`, `pnpm format`, and `pnpm lint` passed.
- `pnpm test`: 76 passed, including creator ordering, renames, coauthor identity resolution, and restoration of shallow checkouts with and without an origin remote.
- `pnpm build`: 68 static pages; configuration, types, formatting, and module-boundary checks passed.
- Firefox: 2-, 12-, and 48-person lists at desktop and mobile widths, including 320 x 320; wrapping, internal scrolling, viewport bounds, and Escape passed. Firefox and Chromium retained normal scrolling at list boundaries.
- A static-only server with external requests blocked retained the expected names and popup behavior; the browser bundles contain no GitHub lookup code.
- All 61 existing article bodies remain byte-for-byte unchanged. Simulated preview data is excluded from the build and commit.

## Notes

Production builds restore complete history before reading credits. GitHub lookups use bounded concurrency, request deduplication, and cached fallbacks; `GITHUB_TOKEN` is optional. Names stay fixed until the next build. The README now documents automatic attribution instead of a manual `author` field.
