### PR TITLE
fix(home): clarify security researcher label

### DIFF
--- a/entropic.config.ts
+++ b/entropic.config.ts
@@ -65,7 +65,7 @@ export default {
             label: "Cybersecurity enthusiast. Idealist. Purist."
           },
           {
-            label: "Offensive Researcher @RaptX",
+            label: "Offensive Security Researcher @RaptX",
             // Link only this part of label; omit to link the whole text.
             linkLabel: "@RaptX",
             href: "https://raptx.org/",


### PR DESCRIPTION
## Summary

Update the homepage profile label to `Offensive Security Researcher @RaptX`.

## Scope

- [x] User-facing behavior
- [x] Content
- [ ] Documentation
- [ ] Tooling or automation
- [ ] Build, CI, or deployment
- [ ] Performance or maintenance

## Verification

- `pnpm check:config`
- `pnpm exec biome check entropic.config.ts`
- `git diff --check`
