### PR TITLE
feat(buttons): add remote 0xStrawHat button

### DIFF
--- a/entropic.config.ts
+++ b/entropic.config.ts
@@ -135,6 +135,11 @@ export default {
         imageSrc: "https://nikolan.net/resources/88x31s/button.png"
       },
       {
+        label: "0xStrawHat",
+        href: "https://0xstrawhat.tech/",
+        imageSrc: "https://0xstrawhat.tech/images/buttons/strawhat.gif"
+      },
+      {
         label: "GitHub",
         href: "https://github.com/CuB3y0nd",
         imageSrc: "/assets/88x31/github.png"


### PR DESCRIPTION
## Summary

Add the 0xStrawHat friend button linking to https://0xstrawhat.tech/. Load its GIF directly from the remote URL so no local image copy is needed.

## Scope

- [x] User-facing behavior

## Verification

- Site configuration validation passes.
- The rendered homepage uses the exact remote GIF URL and 0xStrawHat label.
- GitHub CI must pass before merging.
