### PR TITLE
fix(cves): align responsive layout and site colors

### DIFF
--- a/src/features/cves/components/CveCircuit.astro
+++ b/src/features/cves/components/CveCircuit.astro
@@ -66,7 +66,7 @@ const signals = [
       <path d="M1151 91V84H1094V151H1151M1102 119H1133"></path>
     </g>
 
-    <g class="cve-circuit-accents" stroke="var(--cve-accent)" shape-rendering="crispEdges">
+    <g class="cve-circuit-accents" stroke="var(--link)" shape-rendering="crispEdges">
       <path d="M41 91V126H61M205 162V197H246V161H287V143"></path>
       <path d="M431 19V197H447M424 126H438M453 55H493V116M485 90H503"></path>
       <path d="M778 126V19H788M779 57H788M792 110H817M858 110H876M797 171H819"></path>

--- a/src/features/cves/components/CveScreen.astro
+++ b/src/features/cves/components/CveScreen.astro
@@ -24,7 +24,7 @@ const { groups, summary } = buildCveTimeline(content);
   <div class="cve-timeline">
     <svg class="cve-timeline-art" fill="none" aria-hidden="true" focusable="false">
       <g data-cve-timeline-traces stroke="currentColor" stroke-width="1.15" stroke-linejoin="miter"></g>
-      <g data-cve-timeline-accents stroke="var(--cve-accent)" stroke-width="1.15"></g>
+      <g data-cve-timeline-accents stroke="var(--link)" stroke-width="1.15"></g>
       <g data-cve-timeline-dots fill="currentColor" opacity="0.55"></g>
       <CveSignals />
     </svg>

--- a/src/features/cves/components/CveSignals.astro
+++ b/src/features/cves/components/CveSignals.astro
@@ -15,7 +15,7 @@ const signalWidth = animation.signalSize * unit;
   animation.enabled && (
     <g
       class="cve-circuit-signals"
-      stroke="var(--cve-accent)"
+      stroke="var(--link)"
       shape-rendering="crispEdges"
       style={`--cve-signal-cycle: ${animation.cycleMs}ms`}
     >
@@ -42,7 +42,7 @@ const signalWidth = animation.signalSize * unit;
             y={y - signalWidth / 2}
             width={signalWidth}
             height={signalWidth}
-            fill="var(--cve-accent)"
+            fill="var(--link)"
             stroke="none"
           />
         </g>

--- a/src/features/cves/styles.css
+++ b/src/features/cves/styles.css
@@ -2,8 +2,7 @@
 
 @layer components.features {
   .cve-register {
-    --cve-accent: color-mix(in srgb, var(--link) 20%, #54fff0);
-    --cve-muted: color-mix(in srgb, var(--fg) 68%, var(--bg));
+    --cve-muted: color-mix(in srgb, var(--fg) 68%, var(--home-bg));
     --cve-width: round(down, min(var(--text-cell) * 105, 100% - var(--text-cell) * 4), 2px);
     --cve-line: var(--text-size);
     width: var(--cve-width);
@@ -15,18 +14,16 @@
     line-height: 1;
   }
   .cve-masthead {
+    container-type: inline-size;
     position: relative;
     margin-bottom: 2px;
     overflow: hidden;
   }
   .cve-circuit {
     color: var(--fg);
-    position: relative;
     display: block;
-    width: calc(var(--text-cell) * 105);
-    height: round(up, calc(var(--text-cell) * 105 * 286 / 2048), 1px);
-    max-width: none;
-    left: round(down, (100% - var(--text-cell) * 105) / 2, 1px);
+    width: 100%;
+    height: round(up, calc(100cqw * 286 / 2048), 1px);
   }
   .cve-count {
     position: absolute;
@@ -38,6 +35,7 @@
   }
   .cve-timeline {
     position: relative;
+    margin-inline: calc(var(--text-cell) * 3);
     padding-bottom: 50px;
   }
   .cve-timeline-art {
@@ -62,9 +60,9 @@
     white-space: nowrap;
     margin: 0 auto 8px;
     padding: 0 6px;
-    background: var(--bg);
+    background: var(--home-bg);
     font: inherit;
-    color: var(--cve-accent);
+    color: var(--link);
   }
   .cve-timeline-group h2 small {
     font: inherit;
@@ -108,16 +106,9 @@
     width: calc(100% + var(--text-cell) + 2px);
   }
   .cve-timeline-entry a {
-    color: var(--cve-accent);
     display: inline-block;
     max-width: 100%;
     overflow-wrap: anywhere;
-  }
-  .cve-timeline-entry a:hover,
-  .cve-timeline-entry a:focus-visible {
-    background: transparent;
-    color: var(--cve-accent);
-    text-decoration: underline;
   }
   .cve-recognition-entry {
     padding-left: calc(var(--text-cell) * 10.5);
@@ -196,9 +187,17 @@
       display: none;
     }
   }
-  @media (max-width: 700px) {
+  @media (max-width: 760px) {
     .cve-count {
-      bottom: 0;
+      position: static;
+      display: block;
+      margin-left: auto;
+      margin-top: calc(var(--cve-line) / 2);
+    }
+  }
+  @media (max-width: 700px) {
+    .cve-timeline {
+      margin-inline: var(--text-cell);
     }
     .cve-timeline:not([data-cve-drawn])::before {
       left: 32px;

--- a/src/features/cves/timeline.ts
+++ b/src/features/cves/timeline.ts
@@ -38,25 +38,30 @@ export function installCveTimeline(timeline: HTMLElement): () => void {
   const draw = () => {
     frame = 0;
     const bounds = timeline.getBoundingClientRect();
+    const width = timeline.clientWidth;
+    const height = timeline.clientHeight;
+    if (!width || !height) return;
+    // DOM rectangles include mobile zoom; circuit coordinates use local CSS pixels.
+    const localX = (screenX: number) => ((screenX - bounds.left) * width) / bounds.width;
+    const localY = (screenY: number) => ((screenY - bounds.top) * height) / bounds.height;
     const compact = window.matchMedia("(max-width: 700px)").matches;
     const scale = Number.parseFloat(getComputedStyle(timeline).fontSize) / 14;
-    const center = compact ? 32 * scale : bounds.width / 2;
+    const center = compact ? 32 * scale : width / 2;
     const x = (offset: number) => Math.round(center + offset * scale * (compact ? 0.65 : 1)) + 0.5;
     const traces: SVGElement[] = [];
     const accents: SVGElement[] = [];
     const dots: SVGElement[] = [];
     const routes: { path: string; x: number; y: number }[] = [];
     const groups = [...timeline.querySelectorAll<HTMLElement>(".cve-timeline-group")];
-    art.setAttribute("viewBox", `0 0 ${bounds.width} ${bounds.height}`);
+    art.setAttribute("viewBox", `0 0 ${width} ${height}`);
 
     groups.forEach((group, groupIndex) => {
       const heading = group.querySelector("h2")?.getBoundingClientRect();
       if (!heading) return;
       const nextHeading = groups[groupIndex + 1]?.querySelector("h2")?.getBoundingClientRect();
-      const start = Math.round(heading.bottom - bounds.top + 5 * scale);
-      const end = Math.round(nextHeading ? nextHeading.top - bounds.top - 7 * scale : bounds.height - 2);
-      const height = end - start;
-      const y = (fraction: number) => Math.round(start + height * fraction) + 0.5;
+      const start = Math.round(localY(heading.bottom) + 5 * scale);
+      const end = Math.round(nextHeading ? localY(nextHeading.top) - 7 * scale : height - 2);
+      const y = (fraction: number) => Math.round(start + (end - start) * fraction) + 0.5;
       const entries = [...group.querySelectorAll<HTMLElement>(".cve-timeline-entry")];
       const long = entries.length > 2;
 
@@ -137,19 +142,18 @@ export function installCveTimeline(timeline: HTMLElement): () => void {
         const rect = entry.getBoundingClientRect();
         const lineHeight = Number.parseFloat(getComputedStyle(entry).lineHeight);
         const right = compact || entry.classList.contains("cve-right");
-        const branchY = Math.round(rect.top - bounds.top + lineHeight * (long && index === 1 ? 2.2 : 1.45));
+        const branchY = Math.round(localY(rect.top) + lineHeight * (long && index === 1 ? 2.2 : 1.45));
         const row = (index >> 1) % 6;
         const reach = !long && !right ? 97 : row === 1 ? 57 : row === 2 || row === 3 ? 83 : 71;
-        let edge = compact ? rect.left - bounds.left - 12 * scale : center + (right ? 74 : -reach) * scale;
+        let edge = compact ? localX(rect.left) - 12 * scale : center + (right ? 74 : -reach) * scale;
         for (const text of entry.querySelectorAll("a, p")) {
           const range = document.createRange();
           range.selectNodeContents(text);
-          const screenY = bounds.top + branchY + 0.5;
           for (const line of range.getClientRects()) {
-            if (screenY < line.top || screenY > line.bottom) continue;
+            if (branchY + 0.5 < localY(line.top) || branchY + 0.5 > localY(line.bottom)) continue;
             edge = right
-              ? Math.min(edge, line.left - bounds.left - 12 * scale)
-              : Math.max(edge, line.right - bounds.left + 12 * scale);
+              ? Math.min(edge, localX(line.left) - 12 * scale)
+              : Math.max(edge, localX(line.right) + 12 * scale);
           }
         }
         const conductor = conductors[right ? 2 : 0];

--- a/src/styles/foundation/base.css
+++ b/src/styles/foundation/base.css
@@ -58,8 +58,8 @@ a:focus-visible {
   top: var(--pixel-align-y, 0px);
 }
 
-body:has(.home-shell),
-html:has(.home-shell) {
+body:has(.home-shell, .cve-register),
+html:has(.home-shell, .cve-register) {
   background-color: var(--home-bg);
 }
 

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -22,7 +22,8 @@
     zoom: min(var(--mobile-scale), var(--fit-scale));
   }
 
-  .home-shell {
+  .home-shell,
+  .cve-register {
     zoom: min(var(--mobile-scale), var(--fit-scale));
   }
 

--- a/tests/browser/cve-mobile-layout.mjs
+++ b/tests/browser/cve-mobile-layout.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { baseUrl, browserName, launchBrowser, settleTextLayout, stubExternalResources } from "./support.mjs";
+
+async function renderedText(page, selector) {
+  return page
+    .locator(selector)
+    .first()
+    .evaluate((element) => {
+      const probe = document.createElement("span");
+      probe.textContent = "MMMMMMMM";
+      probe.style.cssText = "position:absolute;visibility:hidden;white-space:pre;font:inherit";
+      element.append(probe);
+      const bounds = probe.getBoundingClientRect();
+      probe.remove();
+      return { glyphWidth: bounds.width / 8, lineHeight: bounds.height };
+    });
+}
+
+const browser = await launchBrowser();
+const failures = [];
+const errors = [];
+try {
+  for (const deviceScaleFactor of [1, 3]) {
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      deviceScaleFactor,
+      isMobile: browserName === "chromium",
+      hasTouch: true,
+      reducedMotion: "reduce"
+    });
+    await stubExternalResources(context);
+    const home = await context.newPage();
+    const cves = await context.newPage();
+    for (const page of [home, cves]) page.on("pageerror", (error) => errors.push(error.message));
+    await home.goto(baseUrl.href);
+    await home.waitForFunction(() => document.querySelector(".home-shell")?.style.getPropertyValue("--fit-scale"));
+    await cves.goto(new URL("/cves/", baseUrl).href);
+    await cves.locator(".cve-timeline[data-cve-drawn]").waitFor();
+
+    for (const width of [390, 320, 700, 760, 844, 390]) {
+      const viewport = { width, height: width === 844 ? 390 : 844 };
+      for (const page of [home, cves]) {
+        await page.setViewportSize(viewport);
+        await settleTextLayout(page);
+      }
+      const homeText = await renderedText(home, ".home-shell > .home-pre");
+      const cveText = await renderedText(cves, ".cve-entry p");
+      const layout = await cves.evaluate(() => {
+        const masthead = document.querySelector(".cve-masthead").getBoundingClientRect();
+        const art = document.querySelector(".cve-circuit").getBoundingClientRect();
+        const count = document.querySelector(".cve-count").getBoundingClientRect();
+        const timeline = document.querySelector(".cve-timeline-art");
+        const detachedBranches = [...document.querySelectorAll(".cve-timeline-entry")].filter((entry) => {
+          const bounds = entry.getBoundingClientRect();
+          const branch = timeline.querySelector(`[data-entry-id="${entry.dataset.entryId}"]`);
+          if (!branch) return true;
+          const line = branch.getBoundingClientRect();
+          return line.top <= bounds.top || line.bottom > bounds.bottom;
+        }).length;
+        return {
+          fullArtVisible: art.left >= masthead.left - 0.1 && art.right <= masthead.right + 0.1,
+          countVisible: count.left >= masthead.left && count.right <= masthead.right + 0.1,
+          countClearsArt: !window.matchMedia("(max-width: 760px)").matches || count.top > art.bottom,
+          detachedBranches,
+          overflow: document.documentElement.scrollWidth > window.innerWidth
+        };
+      });
+      const label = `${width}px at DPR ${deviceScaleFactor}`;
+      if (
+        Math.abs(homeText.glyphWidth - cveText.glyphWidth) > 0.1 ||
+        Math.abs(homeText.lineHeight - cveText.lineHeight) > 0.1
+      ) {
+        failures.push(`${label}: CVE rendered text scale differs from the homepage`);
+      }
+      if (!layout.fullArtVisible) failures.push(`${label}: masthead circuitry is cropped`);
+      if (!layout.countVisible) failures.push(`${label}: record count is clipped`);
+      if (!layout.countClearsArt) failures.push(`${label}: record count needs space below the masthead circuitry`);
+      if (layout.detachedBranches) failures.push(`${label}: circuit branches do not follow their entries`);
+      if (layout.overflow) failures.push(`${label}: horizontal overflow`);
+    }
+    await context.close();
+  }
+  assert.deepEqual(failures, [], "CVE mobile scale and masthead clearance");
+  assert.deepEqual(errors, [], "No browser exceptions");
+  console.log(
+    `PASS ${browserName}: CVE matches homepage scale, keeps the full masthead visible, and clears the count at DPR 1/3 through rotation`
+  );
+} finally {
+  await browser.close();
+}

--- a/tests/browser/cve-records.mjs
+++ b/tests/browser/cve-records.mjs
@@ -93,7 +93,6 @@ try {
       await settleTextLayout(page);
       const actual = await page.evaluate(() => {
         const art = document.querySelector(".cve-timeline-art");
-        const matrix = art.getScreenCTM();
         const tracks = [...art.querySelectorAll("[data-cve-timeline-traces] path")];
         const entries = [...document.querySelectorAll(".cve-entry")];
         return {
@@ -109,20 +108,20 @@ try {
           recognitions: [...document.querySelectorAll(".cve-recognition-entry")].map((entry) => {
             const period = entry.querySelector(".cve-recognition-period");
             const description = entry.querySelector("p");
+            const zoom = entry.getBoundingClientRect().height / entry.offsetHeight;
             return {
               id: entry.id,
               title: entry.querySelector("a").textContent.trim(),
               href: entry.querySelector("a").getAttribute("href"),
               recipient: description.textContent,
               period: period.textContent,
-              gap: period.getBoundingClientRect().top - description.getBoundingClientRect().bottom
+              gap: Math.round((period.getBoundingClientRect().top - description.getBoundingClientRect().bottom) / zoom)
             };
           }),
           branches: [...document.querySelectorAll(".cve-timeline-entry")].map((entry) => {
             const branch = art.querySelector(`[data-entry-id="${entry.dataset.entryId}"]`);
             if (!branch) return { attached: false, overlaps: false };
-            const start = branch.getPointAtLength(0).matrixTransform(matrix);
-            const end = branch.getPointAtLength(branch.getTotalLength()).matrixTransform(matrix);
+            const line = branch.getBoundingClientRect();
             const bounds = entry.getBoundingClientRect();
             const textRects = [...entry.querySelectorAll("a, p")].flatMap((element) => {
               const range = document.createRange();
@@ -131,12 +130,9 @@ try {
             });
             const overlaps = textRects.some(
               (rect) =>
-                end.y > rect.top &&
-                end.y < rect.bottom &&
-                Math.max(start.x, end.x) > rect.left &&
-                Math.min(start.x, end.x) < rect.right
+                line.top > rect.top && line.bottom < rect.bottom && line.right > rect.left && line.left < rect.right
             );
-            return { attached: end.y >= bounds.top && end.y <= bounds.bottom, overlaps };
+            return { attached: line.top >= bounds.top && line.bottom <= bounds.bottom, overlaps };
           }),
           signals: [...art.querySelectorAll(".cve-signal:not([hidden]) .cve-signal-head")].map((head) => {
             const length = head.getTotalLength();

--- a/tests/browser/cve-typography.mjs
+++ b/tests/browser/cve-typography.mjs
@@ -25,6 +25,8 @@ try {
       );
       return {
         overflow: document.documentElement.scrollWidth > window.innerWidth,
+        mobile: window.matchMedia("(max-width: 760px)").matches,
+        mastheadScale: Math.min(1, masthead.width / 840),
         family: theme.getPropertyValue("--text-font").trim(),
         size: theme.getPropertyValue("--text-size").trim(),
         smoothing: getComputedStyle(document.body).webkitFontSmoothing,
@@ -49,8 +51,8 @@ try {
           const id = entry.dataset.entryId;
           const branch = art.querySelector(`[data-entry-id="${id}"]`);
           if (!branch) return { id, connected: false };
-          const end = branch.getPointAtLength(branch.getTotalLength()).matrixTransform(art.getScreenCTM());
-          return { id, connected: end.y > bounds.top && end.y <= bounds.bottom };
+          const line = branch.getBoundingClientRect();
+          return { id, connected: line.top > bounds.top && line.bottom <= bounds.bottom };
         }),
         branches: art.querySelectorAll(".cve-circuit-branch").length,
         invalidPaths: [...art.querySelectorAll("path")].some((path) => /NaN|Infinity/.test(path.getAttribute("d")))
@@ -59,16 +61,24 @@ try {
     assert.equal(layout.overflow, false, `${width}px: no horizontal overflow`);
     assert.equal(layout.letters.length, 3, `${width}px: all three circuit letters are present`);
     for (const letter of layout.letters) {
-      assert.ok(letter.visible, `${width}px: lettering stays inside the cropped masthead`);
-      assert.ok(letter.width >= 24, `${width}px: lettering stays readable`);
+      assert.ok(letter.visible, `${width}px: lettering stays inside the masthead`);
+      assert.ok(letter.width >= 24 * layout.mastheadScale, `${width}px: lettering scales with the masthead`);
     }
     for (const text of layout.text) {
       assert.equal(text.family, layout.family, `${width}px: shared theme font`);
-      assert.equal(text.size, layout.size, `${width}px: shared theme font size`);
-      assert.equal(text.line, layout.size, `${width}px: shared textmode line height`);
+      assert.ok(
+        Math.abs(Number.parseFloat(text.size) - Number.parseFloat(layout.size)) < 0.05,
+        `${width}px: shared theme font size`
+      );
+      assert.ok(
+        Math.abs(Number.parseFloat(text.line) - Number.parseFloat(layout.size)) < 0.05,
+        `${width}px: shared textmode line height`
+      );
       assert.equal(text.smoothing, layout.smoothing, `${width}px: shared bitmap font rendering`);
-      assert.ok(Math.abs(text.x - Math.round(text.x)) < 0.01, `${width}px: text x=${text.x} is on a whole pixel`);
-      assert.ok(Math.abs(text.y - Math.round(text.y)) < 0.01, `${width}px: text y=${text.y} is on a whole pixel`);
+      if (!layout.mobile) {
+        assert.ok(Math.abs(text.x - Math.round(text.x)) < 0.01, `${width}px: text x=${text.x} is on a whole pixel`);
+        assert.ok(Math.abs(text.y - Math.round(text.y)) < 0.01, `${width}px: text y=${text.y} is on a whole pixel`);
+      }
     }
     assert.equal(layout.invalidPaths, false, `${width}px: finite circuit coordinates`);
     assert.equal(layout.branches, layout.entries.length, `${width}px: every record has a branch`);

--- a/tests/browser/run.mjs
+++ b/tests/browser/run.mjs
@@ -7,4 +7,5 @@ await import("./artwork-rotation.mjs");
 await import("./byte-inspector.mjs");
 await import("./fragment-citations.mjs");
 await import("./cve-typography.mjs");
+await import("./cve-mobile-layout.mjs");
 await import("./cve-records.mjs");


### PR DESCRIPTION
## Summary

At a 390px viewport, CVE text rendered twice as wide as homepage text, the fixed-width circuit masthead was cropped, and the record count overlapped its lines. Apply the homepage mobile scaling, resize the complete masthead, move the mobile count into normal flow, and normalize SVG coordinates so branches follow the text after wrapping and resizing.

Inset timeline content from the masthead edges and use the homepage background and shared link, hover, and focus colors for CVE text and circuit effects.

## Scope

- [x] User-facing behavior
- [ ] Content
- [ ] Documentation
- [x] Tooling or automation
- [ ] Build, CI, or deployment
- [ ] Performance or maintenance

## Verification

- `pnpm lint`, `pnpm check`, and `pnpm build` passed; the production build generated 68 pages.
- `pnpm test`: 82 tests passed.
- Chromium and Firefox: rendered text size at DPR 1/3, portrait/landscape transitions, typography and circuit connections across ten widths, and animation lifecycle checks.
- Chromium and Firefox: 16 CVE/recognition fixtures across four widths, including added/removed records, empty states, long descriptions, and configured recognition spacing.
- Default and custom theme colors matched the homepage in normal, hover, and keyboard focus states on desktop and mobile.

## Notes

CVE now follows `appearance.colors.homeBackground`; text, links, and circuit accents follow the existing shared appearance colors.
