### PR TITLE
fix(ui): compact mobile buttons and reading tools

### DIFF
--- a/src/features/home/components/HomeScreen.astro
+++ b/src/features/home/components/HomeScreen.astro
@@ -10,7 +10,7 @@ type Props = { volumes: readonly Volume[] };
 const { asciiText, asciiHtml, homeText } = renderHome(Astro.props.volumes);
 ---
 
-<div class="home-page inline-grid grid-cols-[min-content]">
+<div class="home-page inline-grid grid-cols-[min-content]" data-textmode-fit-scope>
   <section class="home-shell inline-block text-left">
     <div
       class="ascii-hero relative inline-block mb-line"

--- a/src/features/philes/citations/styles.css
+++ b/src/features/philes/citations/styles.css
@@ -47,7 +47,6 @@
   }
   .fragment-panel {
     width: max-content;
-    max-width: min(392px, var(--selection-width, calc(100vw - 24px)));
   }
   .fragment-kind {
     color: color-mix(in srgb, var(--fg) 60%, var(--bg));
@@ -115,6 +114,19 @@
   @media (pointer: coarse) {
     .phile-selection .fragment-url {
       font-size: 16px;
+    }
+  }
+}
+
+@layer responsive {
+  @media (max-width: 760px) {
+    .fragment-field {
+      max-height: min(200px, 40dvh);
+    }
+
+    .fragment-url,
+    .fragment-message {
+      padding: 8px;
     }
   }
 }

--- a/src/features/philes/inspection/styles.css
+++ b/src/features/philes/inspection/styles.css
@@ -36,7 +36,7 @@
   .byte-inspector-controls select {
     min-width: 0;
     max-width: 100%;
-    min-height: 28px;
+    min-height: var(--selection-control-size);
     padding: 2px 4px;
     border: 1px solid color-mix(in srgb, var(--link) 30%, var(--bg));
     background: var(--bg);
@@ -49,6 +49,7 @@
     grid-template-columns: 64px minmax(0, 1fr);
     gap: 8px;
     width: 100%;
+    min-height: var(--selection-row-size);
     padding: 5px 12px;
     border: 0;
     background: transparent;
@@ -79,11 +80,6 @@
   }
 
   @media (pointer: coarse) {
-    .byte-inspector-row,
-    .byte-inspector-controls select {
-      min-height: 44px;
-    }
-
     .byte-inspector-row {
       align-items: center;
     }
@@ -91,6 +87,31 @@
     .byte-inspector-controls select {
       /* Avoid the automatic form-control zoom on mobile Safari. */
       font-size: 16px;
+    }
+  }
+}
+
+@layer responsive {
+  @media (max-width: 760px) {
+    .byte-inspector-rows {
+      padding: 4px 0;
+    }
+
+    .byte-inspector-controls {
+      gap: 6px 8px;
+      padding: 6px 8px;
+    }
+
+    .byte-inspector-controls label {
+      gap: 4px;
+    }
+
+    .byte-inspector-row {
+      padding: 2px 8px;
+    }
+
+    .byte-inspector-note {
+      padding: 0 8px 6px;
     }
   }
 }

--- a/src/features/philes/selection/styles.css
+++ b/src/features/philes/selection/styles.css
@@ -2,13 +2,17 @@
 
 @layer components.features {
   .phile-selection {
+    --selection-control-size: 28px;
+    --selection-row-size: 0px;
+    --selection-panel-width: 392px;
+    --selection-panel-height: 100dvh;
     position: fixed;
     z-index: 80;
     width: max-content;
     max-width: var(--selection-width, calc(100vw - 24px));
     color: var(--fg);
     font-family: var(--text-font);
-    font-size: 14px;
+    font-size: var(--text-size);
     line-height: 20px;
     text-align: left;
   }
@@ -31,12 +35,18 @@
     outline: 1px solid var(--link);
     outline-offset: -3px;
   }
+  .selection-actions,
+  .selection-panel {
+    /* The outer wrapper keeps placement in viewport pixels. */
+    zoom: var(--reading-tool-scale);
+  }
   .selection-actions {
     display: flex;
     border: 1px solid color-mix(in srgb, var(--link) 55%, var(--bg));
     background: var(--bg);
   }
   .selection-trigger {
+    min-height: var(--selection-control-size);
     padding: 4px 8px;
     border: 0;
     background: transparent;
@@ -48,9 +58,15 @@
   }
   .selection-panel {
     box-sizing: border-box;
-    width: 392px;
-    max-width: var(--selection-width, calc(100vw - 24px));
-    max-height: var(--selection-height, calc(100dvh - 24px));
+    width: var(--selection-panel-width);
+    max-width: min(
+      var(--selection-panel-width),
+      calc(var(--selection-width, calc(100vw - 24px)) / var(--reading-tool-scale))
+    );
+    max-height: calc(
+      min(var(--selection-panel-height), var(--selection-height, calc(100dvh - 24px))) /
+      var(--reading-tool-scale)
+    );
     overflow-y: auto;
     overscroll-behavior-y: contain;
     scrollbar-width: thin;
@@ -64,8 +80,28 @@
     color: var(--link);
   }
   @media (pointer: coarse) {
+    .phile-selection {
+      --selection-control-size: 44px;
+      --selection-row-size: 44px;
+    }
+  }
+}
+
+@layer responsive {
+  @media (max-width: 760px) {
+    .phile-selection {
+      --selection-control-size: 40px;
+      --selection-row-size: 32px;
+      --selection-panel-height: min(360px, 60dvh);
+      line-height: 18px;
+    }
+
     .selection-trigger {
-      min-height: 44px;
+      padding: 2px 6px;
+    }
+
+    .selection-heading {
+      padding: 6px 8px;
     }
   }
 }

--- a/src/features/site-badges/client/gallery.js
+++ b/src/features/site-badges/client/gallery.js
@@ -1,0 +1,42 @@
+(() => {
+  const browser = document.currentScript?.previousElementSibling;
+  const toggle = browser?.querySelector(".badge-toggle");
+  const dialog = browser?.querySelector(".badge-dialog");
+  const body = dialog?.querySelector(".badge-dialog-body");
+  const actions = browser?.querySelector(".badge-actions");
+  if (!(toggle instanceof HTMLButtonElement) || !(dialog instanceof HTMLDialogElement) || !body || !actions) return;
+
+  const mobile = window.matchMedia("(max-width: 760px)");
+  browser.dataset.modal = "";
+  toggle.hidden = false;
+  toggle.addEventListener("click", () => {
+    if (!mobile.matches || dialog.open) return;
+    body.append(actions);
+    dialog.showModal();
+    toggle.setAttribute("aria-expanded", "true");
+  });
+  dialog.querySelector(".badge-dialog-close").addEventListener("click", () => dialog.close());
+  dialog.addEventListener("click", (event) => {
+    if (event.target !== dialog) return;
+    const box = dialog.getBoundingClientRect();
+    if (
+      event.clientX < box.left ||
+      event.clientX > box.right ||
+      event.clientY < box.top ||
+      event.clientY > box.bottom
+    ) {
+      dialog.close();
+    }
+  });
+  dialog.addEventListener("close", () => {
+    for (const popover of actions.querySelectorAll(":popover-open")) popover.hidePopover();
+    // Move the original controls back so copying, focus and artwork rotation
+    // never depend on a second set of buttons.
+    browser.insertBefore(actions, dialog);
+    toggle.setAttribute("aria-expanded", "false");
+    if (mobile.matches) toggle.focus({ preventScroll: true });
+  });
+  mobile.addEventListener("change", () => {
+    if (!mobile.matches && dialog.open) dialog.close();
+  });
+})();

--- a/src/features/site-badges/components/BadgeActions.astro
+++ b/src/features/site-badges/components/BadgeActions.astro
@@ -1,11 +1,35 @@
 ---
 import type { SiteBadge } from "../model";
+import galleryScript from "../client/gallery.js?raw";
 import BadgeAction from "./BadgeAction.astro";
 
 type Props = { badges: readonly SiteBadge[]; hasOverlap: boolean };
 const { badges, hasOverlap } = Astro.props;
+const dialogId = `site-buttons-${crypto.randomUUID()}`;
 ---
 
-<ul class="badge-actions">
-  {badges.map((badge) => <BadgeAction badge={badge} hasOverlap={hasOverlap} />)}
-</ul>
+<div class="badge-browser">
+  <button
+    class="badge-toggle"
+    type="button"
+    aria-haspopup="dialog"
+    aria-controls={dialogId}
+    aria-expanded="false"
+    hidden
+  >
+    <span class="badge-toggle-text"
+      ><span aria-hidden="true">[+] </span>Buttons <span class="badge-count">({badges.length})</span></span
+    >
+  </button>
+  <ul class="badge-actions">
+    {badges.map((badge) => <BadgeAction badge={badge} hasOverlap={hasOverlap} />)}
+  </ul>
+  <dialog id={dialogId} class="badge-dialog" aria-labelledby={`${dialogId}-title`}>
+    <header class="badge-dialog-header">
+      <h2 id={`${dialogId}-title`}>Buttons <span class="badge-count">({badges.length})</span></h2>
+      <button class="badge-dialog-close" type="button" aria-label="Close buttons" autofocus>[x]</button>
+    </header>
+    <div class="badge-dialog-body"></div>
+  </dialog>
+</div>
+<script is:inline set:html={galleryScript} />

--- a/src/features/site-badges/styles.css
+++ b/src/features/site-badges/styles.css
@@ -114,14 +114,11 @@
     }
 
     .badge-panel:is([data-placement="left"], [data-placement="right"]) .badge-actions {
-      align-self: end;
       justify-content: start;
     }
   }
 
   .badge-actions {
-    /* Each badge reveal must paint above the decoration. */
-    grid-area: actions;
     display: grid;
     grid-template-columns: repeat(auto-fit, var(--badge-width));
     justify-content: center;
@@ -129,6 +126,79 @@
     margin: 0;
     padding: 0;
     list-style: none;
+  }
+
+  .badge-browser {
+    grid-area: actions;
+    align-self: end;
+    min-width: 0;
+  }
+
+  .badge-toggle {
+    display: none;
+  }
+
+  .badge-dialog {
+    position: fixed;
+    inset: 0;
+    box-sizing: border-box;
+    width: min(296px, calc(100vw - 24px));
+    max-height: min(70dvh, 440px);
+    margin: auto;
+    padding: 0;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--link) 65%, transparent);
+    background: var(--home-bg, var(--bg));
+    color: var(--fg);
+    font: inherit;
+  }
+
+  .badge-dialog[open] {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .badge-dialog::backdrop {
+    background: color-mix(in srgb, var(--home-bg, var(--bg)) 80%, transparent);
+  }
+
+  .badge-dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-left: 10px;
+  }
+
+  .badge-dialog-header h2 {
+    margin: 0;
+    font: inherit;
+  }
+
+  .badge-dialog-close {
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--link);
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .badge-dialog-close:focus-visible {
+    outline: 1px solid var(--link);
+    outline-offset: -4px;
+  }
+
+  .badge-dialog-body {
+    overflow: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+    padding: 0 4px 8px;
+  }
+
+  .badge-count {
+    color: color-mix(in srgb, var(--fg) 60%, transparent);
   }
 
   .badge-item,
@@ -235,6 +305,14 @@
     color: var(--link);
   }
 
+  .badge-dialog .badge-copy-status:not(:empty) {
+    inset: 6px 0;
+    translate: none;
+    display: grid;
+    place-items: center;
+    padding: 0;
+  }
+
   .badge-copy-dialog {
     box-sizing: border-box;
     width: min(320px, calc(100% - 32px));
@@ -288,5 +366,131 @@
   .badge-copy-dialog :is(textarea, button):focus-visible {
     outline: 1px solid var(--link);
     outline-offset: 2px;
+  }
+}
+
+@layer responsive {
+  @media (max-width: 760px) {
+    html:has(.badge-dialog:modal) {
+      overflow: hidden;
+    }
+
+    .site-badges {
+      margin-top: 16px;
+      padding-inline: 0;
+    }
+
+    .badge-panel {
+      --badge-artwork-overlap: 0px;
+      width: 100%;
+      margin-inline: auto;
+    }
+
+    .badge-composition {
+      grid-template-areas: "art" "actions";
+      grid-template-columns: minmax(0, 1fr);
+      gap: 8px;
+    }
+
+    .badge-composition:has(.badge-browser[data-modal]) {
+      gap: 0;
+    }
+
+    .badge-decoration {
+      grid-area: art;
+      display: flex;
+      align-items: flex-end;
+      justify-content: center;
+      gap: 12px;
+    }
+
+    .badge-artwork {
+      width: auto;
+      height: auto;
+      max-width: min(100%, var(--badge-artwork-width));
+      max-height: 64px;
+      margin: 0;
+      object-fit: contain;
+    }
+
+    .badge-decoration:has(.badge-companion) .badge-artwork {
+      max-width: min(var(--badge-artwork-width), (100% - 12px) / 2);
+    }
+
+    .badge-companion {
+      max-width: calc((100% - 12px) / 2);
+      margin: 0;
+    }
+
+    .badge-companion img {
+      max-height: 64px;
+      object-fit: contain;
+    }
+
+    .badge-browser[data-modal] .badge-toggle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+      width: fit-content;
+      margin-inline: auto;
+      padding-inline: 8px;
+      border: 0;
+      background: transparent;
+      color: var(--link);
+      font: inherit;
+      cursor: pointer;
+      outline: 1px solid transparent;
+      outline-offset: -1px;
+    }
+
+    .badge-toggle-text {
+      white-space: nowrap;
+      zoom: min(var(--mobile-scale), var(--fit-scale));
+    }
+
+    .badge-toggle:is(:focus-visible, :active) {
+      outline-color: var(--link);
+    }
+
+    .badge-actions {
+      justify-content: center;
+      column-gap: 4px;
+      row-gap: 0;
+    }
+
+    .badge-browser[data-modal] > .badge-actions {
+      display: none;
+    }
+
+    .badge-item,
+    .badge-action {
+      height: 44px;
+    }
+
+    .badge-action {
+      display: grid;
+      place-items: center;
+      outline-offset: -1px;
+    }
+
+    .badge-reveal {
+      display: none;
+    }
+
+    .badge-action:is(:focus-visible, :active) {
+      outline-color: var(--link);
+    }
+
+    @media (hover: hover) {
+      .badge-toggle:hover,
+      .badge-dialog-close:hover {
+        background: var(--link-hover-bg);
+      }
+
+      .badge-action:hover {
+        outline-color: var(--link);
+      }
+    }
   }
 }

--- a/src/features/volumes/credits/client.ts
+++ b/src/features/volumes/credits/client.ts
@@ -18,21 +18,35 @@ export function installCredits(): void {
   }
   let anchor: HTMLElement | undefined;
   let panel: HTMLElement | undefined;
+  let positionQueued = false;
 
   const position = () => {
     if (!anchor || !panel?.matches(":popover-open")) return;
     const target = anchor.getBoundingClientRect();
     const bounds = panel.getBoundingClientRect();
+    const scale = Number.parseFloat(getComputedStyle(panel).zoom);
     const viewport = window.visualViewport;
     const leftEdge = (viewport?.offsetLeft ?? 0) + 12;
     const topEdge = (viewport?.offsetTop ?? 0) + 12;
     const rightEdge = leftEdge + (viewport?.width ?? innerWidth) - 24;
     const bottomEdge = topEdge + (viewport?.height ?? innerHeight) - 24;
-    panel.style.left = `${Math.max(leftEdge, Math.min(target.right - bounds.width, rightEdge - bounds.width))}px`;
-    panel.style.top = `${Math.max(topEdge, Math.min(target.bottom + 8, bottomEdge - bounds.height))}px`;
+    // DOM bounds are in viewport pixels; inset lengths follow the panel's zoom.
+    panel.style.left = `${Math.max(leftEdge, Math.min(target.right - bounds.width, rightEdge - bounds.width)) / scale}px`;
+    panel.style.top = `${Math.max(topEdge, Math.min(target.bottom + 8, bottomEdge - bounds.height)) / scale}px`;
   };
   const close = () => {
     if (panel?.matches(":popover-open")) panel.hidePopover();
+  };
+  const schedulePosition = () => {
+    if (positionQueued || !panel?.matches(":popover-open")) return;
+    positionQueued = true;
+    // Article fitting settles on the first animation frame after resizing.
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        positionQueued = false;
+        position();
+      })
+    );
   };
 
   document.addEventListener("click", (event) => {
@@ -48,7 +62,7 @@ export function installCredits(): void {
     panel.togglePopover();
     position();
   });
-  window.addEventListener("resize", position, { passive: true });
+  window.addEventListener("resize", schedulePosition, { passive: true });
   window.addEventListener("scroll", close, { passive: true });
-  window.visualViewport?.addEventListener("resize", position, { passive: true });
+  window.visualViewport?.addEventListener("resize", schedulePosition, { passive: true });
 }

--- a/src/features/volumes/credits/styles.css
+++ b/src/features/volumes/credits/styles.css
@@ -19,33 +19,36 @@
 }
 
 .phile-credits {
+  --credits-padding: 12px;
+  --credits-gap: 8px;
   --credits-max-height: min(440px, calc(100dvh - 24px));
   position: fixed;
   inset: auto;
   box-sizing: border-box;
   width: max-content;
-  max-width: min(360px, calc(100vw - 24px));
-  min-width: min(180px, calc(100vw - 24px));
+  max-width: min(360px, calc((100vw - 24px) / var(--reading-tool-scale)));
+  min-width: min(180px, calc((100vw - 24px) / var(--reading-tool-scale)));
   max-height: var(--credits-max-height);
   margin: 0;
-  padding: 12px 16px;
+  padding: var(--credits-padding) 16px;
   overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--link) 45%, var(--bg));
   background: var(--bg);
   color: var(--fg);
   font-family: var(--text-font);
-  font-size: 14px;
+  font-size: var(--text-size);
   line-height: 1.5;
   text-align: left;
   box-shadow: 0 8px 24px #0007;
   overflow-wrap: anywhere;
+  zoom: var(--reading-tool-scale);
 }
 
 .phile-credits:popover-open {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 8px 0.75ch;
+  gap: var(--credits-gap) 0.75ch;
 }
 
 .phile-credits-label {
@@ -61,7 +64,7 @@
   min-width: 0;
   max-width: 100%;
   /* Keep the label and panel padding visible even in a short viewport. */
-  max-height: calc(var(--credits-max-height) - 26px - 1.5em - 8px);
+  max-height: calc(var(--credits-max-height) - 2 * var(--credits-padding) - 2px - 1lh - var(--credits-gap));
   margin: 0;
   padding: 0;
   overflow: auto;
@@ -81,4 +84,18 @@
 
 .phile-credits li > span {
   color: var(--link);
+}
+
+@media (max-width: 760px) {
+  .phile-credits {
+    --credits-padding: 8px;
+    --credits-gap: 4px;
+    --credits-max-height: calc(min(360px, 60dvh, 100dvh - 24px) / var(--reading-tool-scale));
+    padding-inline: 8px;
+    line-height: 18px;
+  }
+
+  .phile-credits ol {
+    gap: 4px 0.75ch;
+  }
 }

--- a/src/shared/textmode/client/fit.ts
+++ b/src/shared/textmode/client/fit.ts
@@ -37,7 +37,8 @@ export function installTextmodeFit(mobile: MediaQueryList): void {
       const viewportWidth = document.documentElement.clientWidth;
       for (const { element, width } of widths) {
         const scale = Math.min(1, viewportWidth / Math.max(1, width));
-        element.style.setProperty("--fit-scale", scale.toFixed(4));
+        const scope = element.closest<HTMLElement>("[data-textmode-fit-scope]") ?? element;
+        scope.style.setProperty("--fit-scale", scale.toFixed(4));
       }
     });
   };

--- a/src/styles/foundation/tokens.css
+++ b/src/styles/foundation/tokens.css
@@ -13,6 +13,7 @@
   --text-cell: 8px;
   --home-size: 14px;
   --fit-scale: 1;
+  --reading-tool-scale: 1;
   --ansi-black: #15161e;
   --ansi-red: #f7768e;
   --ansi-green: #9ece6a;

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -1,6 +1,7 @@
 @media (max-width: 760px) {
   :root {
     --mobile-scale: 0.95;
+    --reading-tool-scale: max(0.75, var(--mobile-scale));
   }
 
   body {

--- a/tests/browser/artwork-rotation.mjs
+++ b/tests/browser/artwork-rotation.mjs
@@ -16,9 +16,10 @@ try {
   const page = await context.newPage();
   page.on("pageerror", (error) => errors.push(error.message));
   const markup = await context.request.get(baseUrl.href).then((response) => response.text());
+  const configuredCount = [...markup.matchAll(/class="badge-action"/g)].length;
   assert.equal(
-    [...markup.matchAll(/class="badge-action"/g)].length,
-    17,
+    [...markup.matchAll(/class="badge-actions"/g)].length,
+    1,
     "The response contains one set of controls, independent of the artwork catalog"
   );
   const presetIds = [...markup.matchAll(/<template data-artwork-id="([^"]+)"/g)].map((match) => match[1]);
@@ -26,7 +27,8 @@ try {
   const selectedId = () => page.locator(".artwork-rotation").getAttribute("data-active-artwork");
   const artworkRequests = new Set();
   page.on("request", (request) => {
-    if (request.resourceType() === "image" && new URL(request.url()).pathname.startsWith("/_astro/")) {
+    const path = new URL(request.url()).pathname;
+    if (request.resourceType() === "image" && (path.startsWith("/_astro/") || path === "/_image")) {
       artworkRequests.add(request.url());
     }
   });
@@ -38,6 +40,7 @@ try {
   const buttonOrder = () =>
     page.locator(".badge-action > img").evaluateAll((images) => images.map((image) => image.src));
   const deployedOrder = await buttonOrder();
+  assert.equal(deployedOrder.length, configuredCount, "Artwork selection preserves all configured controls");
   assert.ok(presetIds.includes(today));
   for (const time of ["2026-09-06T16:00:00Z", "2026-09-07T15:59:59.999Z"]) {
     await page.clock.setFixedTime(new Date(time));
@@ -52,6 +55,7 @@ try {
   const cycleStart = Math.floor(todayNumber / presetIds.length) * presetIds.length;
   const seen = [];
   for (let offset = 0; offset <= presetIds.length; offset += 1) {
+    await page.setViewportSize({ width: 1280, height: 800 });
     await page.clock.setFixedTime(new Date((cycleStart + offset) * dayMs - shanghaiOffsetMs + 12 * 3_600_000));
     artworkRequests.clear();
     await page.reload();
@@ -72,6 +76,40 @@ try {
       [...artworkRequests].every((url) => selectedSources.has(url)),
       "Inert templates and noscript fallback must not download unselected artwork"
     );
+    if (offset < presetIds.length) {
+      for (const width of [320, 390, 760]) {
+        await page.setViewportSize({ width, height: 800 });
+        await settleTextLayout(page);
+        if (!(await page.locator(".badge-dialog").evaluate((element) => element.open))) {
+          assert.ok(
+            await page.locator(".badge-artwork").isVisible(),
+            `${id} remains visible while buttons are collapsed`
+          );
+          await page.locator(".badge-toggle").click();
+        }
+        const layout = await page.locator(".badge-panel").evaluate((panel) => {
+          const images = [...panel.querySelectorAll(".badge-artwork, .badge-companion img")].map((image) =>
+            image.getBoundingClientRect().toJSON()
+          );
+          return {
+            images,
+            entryTop: panel.querySelector(".badge-toggle").getBoundingClientRect().top,
+            height: panel.getBoundingClientRect().height,
+            overflows: document.documentElement.scrollWidth > innerWidth
+          };
+        });
+        assert.equal(layout.overflows, false, `${id} fits a ${width}px viewport`);
+        assert.ok(layout.height <= 108.1, `${id} keeps the footer compact`);
+        for (const image of layout.images) {
+          assert.ok(image.height > 0 && image.height <= 64.1, `${id} stays compact at ${width}px`);
+          assert.ok(image.left >= 0 && image.right <= width, `${id} stays inside the viewport`);
+          assert.ok(image.bottom <= layout.entryTop + 0.1, `${id} stays above the buttons entry`);
+        }
+        if (layout.images.length > 1) {
+          assert.ok(layout.images[0].right <= layout.images[1].left, `${id} keeps companion art beside the main art`);
+        }
+      }
+    }
   }
   assert.equal(
     new Set(seen.slice(0, presetIds.length)).size,
@@ -79,13 +117,16 @@ try {
     "Every preset appears exactly once in a cycle"
   );
   console.log(
-    `PASS ${browserName}: stable Shanghai dates, midnight rollover, all 25 presets, no boundary repeat, selected images only`
+    `PASS ${browserName}: stable Shanghai dates, midnight rollover, all 25 presets at 320/390/760px, no boundary repeat, selected images only`
   );
 
   // A tab/history restore on a later date rechecks the schedule and preserves
   // a keyboard user's position among the actual controls.
+  await page.setViewportSize({ width: 390, height: 800 });
+  await page.locator(".badge-toggle").click();
   const copyButton = page.getByRole("button", { name: "Copy Discord", exact: true });
   await copyButton.focus();
+  await settleTextLayout(page);
   await copyButton.evaluate((button) => {
     window.originalCopyButton = button;
   });
@@ -98,6 +139,11 @@ try {
   assert.deepEqual(await buttonOrder(), deployedOrder, "History restoration keeps the deployment's button order");
   assert.equal(await copyButton.evaluate((action) => document.activeElement === action), true);
   assert.equal(await copyButton.evaluate((action) => action === window.originalCopyButton), true);
+  assert.equal(
+    await page.locator(".badge-dialog").evaluate((element) => element.open),
+    true,
+    "Artwork rotation preserves the visitor's open gallery"
+  );
   const focusId = await selectedId();
   await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true })));
   assert.equal(await selectedId(), focusId, "Same-period restoration does not redraw the panel");
@@ -168,12 +214,12 @@ try {
   );
   await otherZone.close();
 
-  const noScript = await browser.newContext({ javaScriptEnabled: false });
+  const noScript = await browser.newContext({ javaScriptEnabled: false, viewport: { width: 320, height: 800 } });
   await stubExternalResources(noScript);
   const fallback = await noScript.newPage();
   await fallback.goto(baseUrl.href);
   assert.equal(await fallback.locator(".site-badges").count(), 1);
-  assert.equal(await fallback.locator(".badge-action").count(), 17);
+  assert.equal(await fallback.locator(".badge-action").count(), configuredCount);
   assert.deepEqual(
     await fallback.locator(".badge-action > img").evaluateAll((images) => images.map((image) => image.src)),
     deployedOrder,

--- a/tests/browser/badge-copy.mjs
+++ b/tests/browser/badge-copy.mjs
@@ -30,6 +30,7 @@ try {
       });
     }
     await page.goto(baseUrl.href);
+    if (touch) await page.locator(".badge-toggle").tap();
     const copy = page.getByRole("button", { name: "Copy Discord", exact: true });
     assert.equal(await copy.getAttribute("data-copy-text"), expectedText);
     assert.equal(await copy.getAttribute("href"), null);
@@ -48,7 +49,7 @@ try {
     }
     await page.waitForFunction(() => document.querySelector(".badge-copy-status")?.textContent === "");
 
-    // Rotation replaces the controls; delegation must also read the newly configured value.
+    // Delegation must also read the value of a replacement control.
     const replacementText = "Another user <&>\nsecond line";
     await copy.evaluate((button, text) => {
       const item = button.closest(".badge-item");
@@ -101,6 +102,13 @@ try {
         await dialog.getByRole("button", { name: "Close" }).click();
       }
       await dialog.waitFor({ state: "hidden" });
+      if (touch) {
+        assert.equal(
+          await page.locator(".badge-dialog").evaluate((element) => element.open),
+          true,
+          "Closing the copy fallback leaves the gallery open"
+        );
+      }
     }
     await context.close();
     console.log(

--- a/tests/browser/byte-inspector.mjs
+++ b/tests/browser/byte-inspector.mjs
@@ -180,6 +180,8 @@ try {
     await selectArticleText(page, "0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0");
     const trigger = page.locator("[data-inspect-trigger]");
     await trigger.waitFor({ state: "visible" });
+    const entryBox = await trigger.boundingBox();
+    assert.ok(entryBox.height >= 28 && entryBox.height <= 32, "The phone entry stays compact and tappable");
     await trigger.tap();
     const panel = page.getByRole("dialog", { name: "Byte inspector" });
     await page.getByRole("combobox", { name: "View", exact: true }).selectOption("bits");
@@ -191,6 +193,8 @@ try {
     assert.ok(await view.isVisible(), "View controls remain reachable while long results scroll");
     const toolbarBox = await view.boundingBox();
     const panelBox = await panel.boundingBox();
+    assert.ok(panelBox.width <= 300, "The phone inspector leaves room beside the article");
+    assert.ok(panelBox.height <= 360.1, "Long results scroll inside a compact panel");
     assert.ok(toolbarBox.y >= panelBox.y && toolbarBox.y + toolbarBox.height < panelBox.y + panelBox.height);
     await page.getByRole("combobox", { name: "Bit width", exact: true }).selectOption("8");
     await page.getByRole("button", { name: "Select HEX: 0xf0", exact: true }).tap();

--- a/tests/browser/credits.mjs
+++ b/tests/browser/credits.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { baseUrl, browserName, launchBrowser, settleTextLayout, stubExternalResources } from "./support.mjs";
+
+const browser = await launchBrowser();
+const errors = [];
+
+try {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    deviceScaleFactor: 3,
+    reducedMotion: "reduce"
+  });
+  await stubExternalResources(context);
+  const page = await context.newPage();
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.goto(new URL("/volume/3/", baseUrl).href);
+  await settleTextLayout(page);
+  const trigger = page.locator("[data-credits-trigger]").first();
+  const panel = page.locator(`[id="${await trigger.getAttribute("popovertarget")}"]`);
+  await trigger.tap();
+  await panel.waitFor({ state: "visible" });
+
+  async function assertPlacement() {
+    const target = await trigger.boundingBox();
+    const bounds = await panel.boundingBox();
+    const viewport = page.viewportSize();
+    const left = Math.max(12, Math.min(target.x + target.width - bounds.width, viewport.width - 12 - bounds.width));
+    const top = Math.max(12, Math.min(target.y + target.height + 8, viewport.height - 12 - bounds.height));
+    assert.ok(Math.abs(bounds.x - left) < 1 && Math.abs(bounds.y - top) < 1, "Credits stay beside their trigger");
+    assert.ok(bounds.x >= 11.9 && bounds.x + bounds.width <= viewport.width - 11.9, "Credits fit the viewport width");
+    assert.ok(
+      bounds.y >= 11.9 && bounds.y + bounds.height <= viewport.height - 11.9,
+      "Credits fit the viewport height"
+    );
+  }
+
+  // Keep the popover open while article fitting changes across breakpoints.
+  for (const width of [390, 320, 700, 760, 1280, 390]) {
+    await page.setViewportSize({ width, height: width === 320 ? 568 : width === 700 ? 360 : 844 });
+    await settleTextLayout(page);
+    await assertPlacement();
+    if (width === 390) {
+      const bounds = await panel.boundingBox();
+      assert.ok(bounds.width <= 300 && bounds.height <= 40, "A short contributor list stays compact on phones");
+    }
+  }
+
+  await page.keyboard.press("Escape");
+  assert.equal(await panel.isVisible(), false);
+  await trigger.tap();
+  await page.touchscreen.tap(4, 4);
+  assert.equal(await panel.isVisible(), false, "Tapping outside dismisses credits");
+  await trigger.press("Enter");
+  await panel.waitFor({ state: "visible" });
+
+  // Exercise a longer list without adding synthetic authors to site content.
+  await panel.locator("ol").evaluate((list) => {
+    for (let index = 0; index < 120; index++) {
+      const item = document.createElement("li");
+      const link = document.createElement("a");
+      link.href = `https://example.test/contributor/${index}`;
+      link.textContent = `Contributor ${index}`;
+      item.append(link);
+      list.append(item);
+    }
+  });
+  await page.setViewportSize({ width: 390, height: 400 });
+  await settleTextLayout(page);
+  await assertPlacement();
+  const list = panel.locator("ol");
+  assert.ok(await list.evaluate((node) => node.scrollHeight > node.clientHeight), "Long contributor lists scroll");
+  const scrollY = await page.evaluate(() => window.scrollY);
+  await list.locator("a").last().focus();
+  const last = await list.locator("a").last().boundingBox();
+  const bounds = await panel.boundingBox();
+  assert.ok(
+    last.y >= bounds.y && last.y + last.height <= bounds.y + bounds.height,
+    "The last contributor is reachable"
+  );
+  assert.equal(await page.evaluate(() => window.scrollY), scrollY, "Scrolling credits keeps the page stationary");
+  assert.deepEqual(errors, [], "Browser exceptions");
+  await context.close();
+  console.log(`PASS ${browserName}: compact credits, resize anchoring, touch, keyboard and long lists`);
+} finally {
+  await browser.close();
+}

--- a/tests/browser/cve-mobile-layout.mjs
+++ b/tests/browser/cve-mobile-layout.mjs
@@ -33,7 +33,9 @@ try {
     const cves = await context.newPage();
     for (const page of [home, cves]) page.on("pageerror", (error) => errors.push(error.message));
     await home.goto(baseUrl.href);
-    await home.waitForFunction(() => document.querySelector(".home-shell")?.style.getPropertyValue("--fit-scale"));
+    await home.waitForFunction(() =>
+      document.querySelector("[data-textmode-fit-scope]")?.style.getPropertyValue("--fit-scale")
+    );
     await cves.goto(new URL("/cves/", baseUrl).href);
     await cves.locator(".cve-timeline[data-cve-drawn]").waitFor();
 

--- a/tests/browser/fragment-citations.mjs
+++ b/tests/browser/fragment-citations.mjs
@@ -154,9 +154,14 @@ try {
   const cjk = "不开心，不想说话";
   await selectArticleText(page, cjk);
   const trigger = page.locator("[data-fragment-trigger]");
+  await trigger.waitFor({ state: "visible" });
+  const triggerBox = await trigger.boundingBox();
+  assert.ok(triggerBox.height >= 28 && triggerBox.height <= 32, "The phone link entry is compact and tappable");
   await trigger.tap();
   const field = page.getByRole("textbox", { name: "Link to selected text" });
   await field.waitFor({ state: "visible" });
+  const linkBox = await page.getByRole("dialog", { name: "Fragment link", exact: true }).boundingBox();
+  assert.ok(linkBox.width <= 300 && linkBox.height <= 200, "The phone link panel stays compact");
   const cjkUrl = await field.inputValue();
   await field.tap();
   assert.deepEqual(await field.evaluate((node) => [node.selectionStart, node.selectionEnd]), [0, cjkUrl.length]);

--- a/tests/browser/run.mjs
+++ b/tests/browser/run.mjs
@@ -6,6 +6,7 @@ await import("./badge-copy.mjs");
 await import("./artwork-rotation.mjs");
 await import("./byte-inspector.mjs");
 await import("./fragment-citations.mjs");
+await import("./credits.mjs");
 await import("./cve-typography.mjs");
 await import("./cve-mobile-layout.mjs");
 await import("./cve-records.mjs");

--- a/tests/browser/site-badges.mjs
+++ b/tests/browser/site-badges.mjs
@@ -12,59 +12,140 @@ try {
       viewport: { width: touch ? 390 : 1280, height: 800 }
     });
     await stubExternalResources(context);
+    const markup = await context.request.get(baseUrl.href).then((response) => response.text());
+    const configuredCount = [...markup.matchAll(/class="badge-action"/g)].length;
+    assert.ok(configuredCount > 0, "The page provides configured buttons");
     const page = await context.newPage();
     page.on("pageerror", (error) => errors.push(error.message));
-    for (const width of touch ? [390, 320, 760] : [1280, 899]) {
-      await page.setViewportSize({ width, height: 800 });
+    for (const width of touch ? [390, 320, 375, 414, 700, 760] : [1280, 899]) {
+      await page.setViewportSize({ width, height: width === 320 ? 568 : width === 700 ? 360 : 800 });
       await page.goto(baseUrl.href);
+      // The development toolbar is absent from production and can cover the
+      // last rows on short phone viewports.
+      await page.addStyleTag({ content: "astro-dev-toolbar { display: none; }" });
       await settleTextLayout(page);
       const panel = page.locator(".site-badges");
       const artwork = panel.locator(".badge-artwork");
+      const dialog = panel.locator(".badge-dialog");
+      const toggle = panel.locator(".badge-toggle");
       await artwork.scrollIntoViewIfNeeded();
       await artwork.evaluate((image) => image.decode());
       const actions = panel.locator(".badge-action");
-      assert.equal(await actions.count(), 17);
+      assert.equal(await actions.count(), configuredCount, "All configured buttons remain available");
       const order = await actions.evaluateAll((elements) =>
         elements.map((element) => element.querySelector("img").src)
       );
       deployedOrder ??= order;
-      assert.deepEqual(
-        order,
-        deployedOrder,
-        "A deployment keeps the same order across refreshes, visitors, and viewports"
-      );
+      assert.deepEqual(order, deployedOrder, "Gallery and viewport changes preserve the deployment's order");
+      assert.equal(await panel.locator(".badge-actions").count(), 1, "The gallery shares the original controls");
       const image = await artwork.evaluate((element) => ({
         currentSrc: element.currentSrc,
         alt: element.alt,
-        hidden: element.getAttribute("aria-hidden"),
-        width: Number(element.getAttribute("width")),
-        height: Number(element.getAttribute("height"))
+        hidden: element.getAttribute("aria-hidden")
       }));
-      assert.ok(image.currentSrc.endsWith(".webp"), "Local artwork uses the build image pipeline");
+      const artworkUrl = new URL(image.currentSrc);
+      assert.ok(
+        artworkUrl.pathname.endsWith(".webp") ||
+          (artworkUrl.pathname === "/_image" && artworkUrl.searchParams.get("f") === "webp"),
+        "Local artwork uses the optimized image pipeline"
+      );
       assert.equal(image.alt, "");
       assert.equal(image.hidden, "true");
-      assert.ok(image.width > 0 && image.height > 0);
+      if (width <= 760) {
+        await toggle.scrollIntoViewIfNeeded();
+        assert.equal(await dialog.evaluate((element) => element.open), false, "Mobile starts with the gallery closed");
+        assert.equal(await actions.first().isVisible(), false, "Collapsed buttons leave the main content prominent");
+        assert.equal(await toggle.locator(".badge-count").textContent(), `(${configuredCount})`);
+        assert.ok((await toggle.boundingBox()).height >= 44, "The gallery entry has a generous touch target");
+        assert.ok((await panel.boundingBox()).height <= 108.1, "The closed footer stays compact");
+        assert.ok((await artwork.boundingBox()).height <= 64.1, "Artwork remains visible at a smaller size");
+        const entry = await panel.evaluate((element) => {
+          const art = element.querySelector(".badge-decoration").getBoundingClientRect();
+          const toggle = element.querySelector(".badge-toggle").getBoundingClientRect();
+          const row = element.querySelector(".badge-composition").getBoundingClientRect();
+          const glyph = (target) => {
+            const walker = document.createTreeWalker(target, NodeFilter.SHOW_TEXT);
+            for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+              const index = node.textContent.search(/[A-Za-z]/);
+              if (index < 0) continue;
+              const range = document.createRange();
+              range.setStart(node, index);
+              range.setEnd(node, index + 1);
+              const bounds = range.getBoundingClientRect();
+              return { width: bounds.width, height: bounds.height };
+            }
+          };
+          const label = element.querySelector(".badge-toggle-text");
+          return {
+            gap: toggle.top - art.bottom,
+            centerOffset: art.left + art.width / 2 - toggle.left - toggle.width / 2,
+            rowOffset: toggle.left + toggle.width / 2 - row.left - row.width / 2,
+            bodyGlyph: glyph(document.querySelector(".home-shell > .home-pre")),
+            labelGlyph: glyph(label),
+            font: getComputedStyle(label).fontFamily
+          };
+        });
+        assert.ok(Math.abs(entry.gap) < 0.1, "The entry sits directly below the decoration");
+        assert.ok(Math.abs(entry.centerOffset) < 0.1, "Art and text share a horizontal center");
+        assert.ok(Math.abs(entry.rowOffset) < 0.1, "The stacked group is centered beneath the homepage");
+        assert.ok(entry.font.includes("gohu"), "The entry uses the site font");
+        assert.ok(Math.abs(entry.bodyGlyph.width - entry.labelGlyph.width) < 0.02, "Entry glyphs match body width");
+        assert.ok(Math.abs(entry.bodyGlyph.height - entry.labelGlyph.height) < 0.02, "Entry glyphs match body height");
+        const before = await page.locator(".home-shell").boundingBox();
+        assert.ok((await panel.boundingBox()).width <= before.width + 0.1, "The footer fits the ASCII masthead");
+        await toggle.tap();
+        await dialog.waitFor({ state: "visible" });
+        assert.equal(
+          await dialog.evaluate((element) => element.matches(":modal")),
+          true,
+          "One tap opens the modal gallery"
+        );
+        assert.equal(await toggle.getAttribute("aria-expanded"), "true");
+        assert.equal(
+          await panel.locator(".badge-dialog-close").evaluate((element) => element === document.activeElement),
+          true
+        );
+        assert.ok(await actions.first().isVisible());
+        const after = await page.locator(".home-shell").boundingBox();
+        assert.deepEqual(after, before, "Opening the gallery does not move or resize the homepage");
+        const bounds = await dialog.boundingBox();
+        assert.ok(bounds.x >= 0 && bounds.x + bounds.width <= width, "The gallery fits the viewport");
+        assert.ok(
+          bounds.y >= 0 && bounds.y + bounds.height <= page.viewportSize().height,
+          "Short screens scroll inside the gallery"
+        );
+        const columns = await actions.evaluateAll(
+          (elements) => new Set(elements.map((element) => element.getBoundingClientRect().left)).size
+        );
+        assert.equal(columns, Math.min(configuredCount, 3), "The gallery uses three native-size columns");
+        assert.equal(await panel.locator(".badge-artwork").count(), 1, "The decoration is not duplicated on expansion");
+      } else {
+        assert.equal(await dialog.evaluate((element) => element.open), false);
+        assert.ok(await actions.first().isVisible(), "Desktop buttons remain visible");
+        assert.equal(await toggle.isVisible(), false, "Desktop needs no disclosure control");
+      }
+      // Switch from tapping the gallery entry to real keyboard input before
+      // checking :focus-visible; programmatic focus alone keeps touch modality.
+      await page.keyboard.press("Tab");
       for (const action of await actions.all()) {
+        await action.focus();
         const geometry = await action.boundingBox();
         assert.ok(Math.abs(geometry.width - 88) < 0.01);
-        assert.ok(Math.abs(geometry.height - 31) < 0.01);
-        assert.ok(geometry.x >= 0 && geometry.x + geometry.width <= width, "Badges remain inside narrow viewports");
+        assert.ok(Math.abs(geometry.height - (width <= 760 ? 44 : 31)) < 0.01);
+        const badge = await action.locator(":scope > img").boundingBox();
+        assert.ok(Math.abs(badge.width - 88) < 0.01 && Math.abs(badge.height - 31) < 0.01);
+        assert.ok(geometry.x >= 0 && geometry.x + geometry.width <= width, "Buttons stay inside the viewport");
         if ((await action.getAttribute("target")) === "_blank") {
           assert.ok((await action.getAttribute("rel")).includes("noopener"));
         }
-        await action.focus();
         const reveal = action.locator(".badge-reveal");
-        if (await reveal.count()) {
-          assert.equal(
-            await reveal.evaluate((element) => getComputedStyle(element).opacity),
-            "1",
-            "Keyboard focus reveals the badge above overlapping art"
-          );
+        if (await reveal.isVisible()) {
+          assert.equal(await reveal.evaluate((element) => getComputedStyle(element).opacity), "1");
         } else {
           assert.notEqual(
             await action.evaluate((element) => getComputedStyle(element).outlineColor),
             "rgba(0, 0, 0, 0)",
-            "Keyboard focus remains visible without overlapping art"
+            "Keyboard focus remains visible"
           );
         }
         assert.ok(
@@ -72,22 +153,15 @@ try {
             const box = element.getBoundingClientRect();
             return element.contains(document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2));
           }),
-          "Decorative artwork never intercepts controls"
+          "Every button can scroll into view and decorations never intercept it"
         );
       }
-      await page.locator("body").click({ position: { x: 1, y: 1 } });
       if (touch) {
-        if (await actions.first().locator(".badge-reveal").count()) {
-          assert.equal(
-            await actions
-              .first()
-              .locator(".badge-reveal")
-              .evaluate((element) => getComputedStyle(element).opacity),
-            "1",
-            "Touch devices do not require hover to reveal buttons"
-          );
-        }
-        // Prevent external navigation while verifying the first tap activates the real action.
+        assert.equal(
+          await page.locator(".screen").evaluate((screen) => screen.scrollTop),
+          0,
+          "The page scrolls without a nested panel"
+        );
         await actions.first().evaluate((element) =>
           element.addEventListener(
             "click",
@@ -98,10 +172,69 @@ try {
             { once: true }
           )
         );
-        await actions.first().tap();
-        assert.equal(await actions.first().getAttribute("data-activated"), "true");
+        await actions.first().tap({ position: { x: 44, y: 2 } });
+        assert.equal(
+          await actions.first().getAttribute("data-activated"),
+          "true",
+          "The larger touch target activates on its first tap"
+        );
+        await page.keyboard.press("Escape");
+        await page.waitForFunction(
+          () => document.querySelector(".badge-toggle").getAttribute("aria-expanded") === "false"
+        );
+        assert.equal(
+          await toggle.evaluate((element) => element === document.activeElement),
+          true,
+          "Closing restores focus to the entry"
+        );
+        assert.equal(await actions.first().isVisible(), false);
+        await toggle.press("Enter");
+        await dialog.waitFor({ state: "visible" });
+        await panel.locator(".badge-dialog-close").tap();
+        await page.waitForFunction(
+          () => document.querySelector(".badge-toggle").getAttribute("aria-expanded") === "false"
+        );
+        await toggle.press("Space");
+        await dialog.waitFor({ state: "visible" });
+        await page.touchscreen.tap(4, 4);
+        await page.waitForFunction(
+          () => document.querySelector(".badge-toggle").getAttribute("aria-expanded") === "false"
+        );
+        assert.equal(
+          await actions.first().isVisible(),
+          false,
+          "Escape, close button and backdrop all dismiss the gallery"
+        );
       }
-      console.log(`PASS ${browserName}: site badges at ${width}px, ${touch ? "touch" : "keyboard"}, optimized artwork`);
+      console.log(
+        `PASS ${browserName}: buttons at ${width}px, ${touch ? "gallery, alignment and touch" : "desktop keyboard"}`
+      );
+    }
+    if (touch) {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await settleTextLayout(page);
+      assert.ok(await page.locator(".badge-action").last().isVisible());
+      await page.setViewportSize({ width: 390, height: 800 });
+      await settleTextLayout(page);
+      assert.equal(
+        await page.locator(".badge-dialog").evaluate((element) => element.open),
+        false,
+        "Returning to mobile preserves the closed state"
+      );
+      await page.locator(".badge-toggle").tap();
+      await settleTextLayout(page);
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await settleTextLayout(page);
+      await page.waitForFunction(() => document.querySelector(".badge-browser > .badge-actions"));
+      assert.equal(await page.locator(".badge-dialog").evaluate((element) => element.open), false);
+      assert.ok(await page.locator(".badge-action").last().isVisible(), "Desktop restores the original controls");
+      await page.setViewportSize({ width: 390, height: 800 });
+      await settleTextLayout(page);
+      assert.equal(
+        await page.locator(".badge-dialog").evaluate((element) => element.open),
+        false,
+        "Returning from desktop starts with a compact mobile footer"
+      );
     }
     await context.close();
   }

--- a/tests/browser/textmode-fit.mjs
+++ b/tests/browser/textmode-fit.mjs
@@ -29,13 +29,15 @@ async function createContext({ holdFont = Promise.resolve(), width = 390 } = {})
 async function readFit(page) {
   return page.evaluate(() => ({
     segments: window.fitSegmentCalls,
-    scale: Number(document.querySelector(".home-shell, .textmode-wrap")?.style.getPropertyValue("--fit-scale"))
+    scale: Number(
+      document.querySelector("[data-textmode-fit-scope], .textmode-wrap")?.style.getPropertyValue("--fit-scale")
+    )
   }));
 }
 
 async function waitForFit(page) {
   await page.waitForFunction(() =>
-    document.querySelector(".home-shell, .textmode-wrap")?.style.getPropertyValue("--fit-scale")
+    document.querySelector("[data-textmode-fit-scope], .textmode-wrap")?.style.getPropertyValue("--fit-scale")
   );
   await settle(page);
 }
@@ -87,7 +89,9 @@ try {
     const delayed = await delayedContext.newPage();
     delayed.on("pageerror", (error) => errors.push(error.message));
     await delayed.goto(baseUrl.href, { waitUntil: "domcontentloaded" });
-    await delayed.waitForFunction(() => document.querySelector(".home-shell")?.style.getPropertyValue("--fit-scale"));
+    await delayed.waitForFunction(() =>
+      document.querySelector("[data-textmode-fit-scope]")?.style.getPropertyValue("--fit-scale")
+    );
     await delayed.waitForTimeout(1500);
     assert.equal(await delayed.evaluate(() => document.fonts.check("14px gohu")), false);
     const fallback = await readFit(delayed);
@@ -95,7 +99,8 @@ try {
     font.resolve();
     await settle(delayed);
     await delayed.waitForFunction(
-      (expected) => Number(document.querySelector(".home-shell")?.style.getPropertyValue("--fit-scale")) === expected,
+      (expected) =>
+        Number(document.querySelector("[data-textmode-fit-scope]")?.style.getPropertyValue("--fit-scale")) === expected,
       homeScale
     );
     assert.ok((await readFit(delayed)).segments > fallback.segments, "Font completion invalidates prepared widths");


### PR DESCRIPTION
## Summary

Mobile homepages now show a small centered decoration above a Gohu-scaled `Buttons (N)` entry. The entry opens the original buttons in a compact three-column dialog, keeping the ASCII artwork and navigation prominent. Copying, daily artwork rotation, keyboard dismissal and the inline no-JavaScript fallback remain available.

Selection actions, inspector/link panels and Contributors share a mobile scale and tighter spacing. Long results scroll inside bounded panels. Credits stay anchored after viewport changes, with positioning scheduled only while open.

## Scope

- [x] User-facing behavior
- [ ] Content
- [ ] Documentation
- [ ] Tooling or automation
- [ ] Build, CI, or deployment
- [x] Performance or maintenance

## Verification

- `pnpm lint`
- `pnpm test` — 82 tests passed
- `pnpm build` — includes configuration, Astro/TypeScript, formatting and boundary checks; 68 pages built
- Chromium and Firefox: mobile/desktop button layouts, copying, artwork rotation and text fitting; compact inspector/link panels; Contributors resize anchoring, touch/keyboard dismissal and long-list scrolling

## Notes

Desktop layouts retain their existing geometry. Browser regression coverage includes the mobile breakpoints and returning to desktop with a popover open.
