### PR TITLE
fix(selection): avoid native touch controls

### DIFF
--- a/src/features/philes/selection/client.ts
+++ b/src/features/philes/selection/client.ts
@@ -27,6 +27,7 @@ export function installSelectionTools(): void {
   const root = document.querySelector<HTMLElement>("[data-selection-tools]");
   const actions = root?.querySelector<HTMLElement>("[data-selection-actions]");
   if (!root || !actions || root.dataset.installed) return;
+  const touch = window.matchMedia("(pointer: coarse)");
   let candidate: Candidate | null = null;
   let active: SelectionTool | null = null;
   let dismissedRange: Range | null = null;
@@ -78,11 +79,17 @@ export function installSelectionTools(): void {
     root.style.setProperty("--selection-height", `${bottomEdge - topEdge}px`);
     const width = root.offsetWidth;
     const height = root.offsetHeight;
-    const below = rect.bottom + 8;
-    const above = rect.top - height - 8;
-    const top = below + height <= bottomEdge ? below : Math.max(topEdge, above);
+    // Native handles extend below touch selections. Near the top edge, the
+    // system action menu can also move below the text. These are viewport
+    // pixels, independent of the article and tool font scales.
+    const touchEntry = touch.matches && !actions.hidden;
+    const handleGap = touchEntry ? 32 : 8;
+    const menuGap = touchEntry ? 80 : 8;
+    const below = rect.bottom + (rect.top - topEdge < menuGap ? menuGap : handleGap);
+    const above = rect.top - height - menuGap;
+    const top = below + height <= bottomEdge ? below : above;
     root.style.left = `${Math.max(leftEdge, Math.min(rect.left, rightEdge - width))}px`;
-    root.style.top = `${Math.min(top, Math.max(topEdge, bottomEdge - height))}px`;
+    root.style.top = `${Math.max(topEdge, Math.min(top, bottomEdge - height))}px`;
     return true;
   };
 

--- a/tests/browser/run.mjs
+++ b/tests/browser/run.mjs
@@ -6,6 +6,7 @@ await import("./badge-copy.mjs");
 await import("./artwork-rotation.mjs");
 await import("./byte-inspector.mjs");
 await import("./fragment-citations.mjs");
+await import("./selection-placement.mjs");
 await import("./credits.mjs");
 await import("./cve-typography.mjs");
 await import("./cve-mobile-layout.mjs");

--- a/tests/browser/selection-placement.mjs
+++ b/tests/browser/selection-placement.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import {
+  baseUrl,
+  browserName,
+  launchBrowser,
+  selectArticleText,
+  settleTextLayout,
+  stubExternalResources
+} from "./support.mjs";
+
+const browser = await launchBrowser();
+const errors = [];
+const overlaps = (first, second) =>
+  first.left < second.right && first.right > second.left && first.top < second.bottom && first.bottom > second.top;
+
+try {
+  for (const [width, height, hasTouch] of [
+    [390, 844, true],
+    [320, 568, true],
+    [760, 360, true],
+    [1280, 800, false]
+  ]) {
+    const context = await browser.newContext({ viewport: { width, height }, hasTouch, reducedMotion: "reduce" });
+    await stubExternalResources(context);
+    const page = await context.newPage();
+    page.on("pageerror", (error) => errors.push(error.message));
+    for (const targetY of [20, height / 2, height - 36]) {
+      await page.goto(new URL("/volume/3/inspect-field-notes/", baseUrl).href);
+      await settleTextLayout(page);
+      // Leave scroll room to place this passage at either viewport edge.
+      await page.addStyleTag({ content: "body { padding-top: 100vh; }" });
+      await selectArticleText(page, "0x2f3", ".phile-body-pre", targetY);
+      const trigger = page.locator("[data-inspect-trigger]");
+      await trigger.waitFor({ state: "visible" });
+      const { selection, actions } = await page.evaluate(() => ({
+        selection: getSelection().getRangeAt(0).getBoundingClientRect().toJSON(),
+        actions: document.querySelector("[data-selection-actions]").getBoundingClientRect().toJSON()
+      }));
+      const label = `${width}x${height} selection at ${targetY}`;
+      assert.ok(Math.abs(selection.top - targetY) < 1, `${label}: the selection reaches the intended position`);
+      assert.ok(actions.left >= 11.9 && actions.right <= width - 11.9, `${label}: tools fit horizontally`);
+      assert.ok(actions.top >= 11.9 && actions.bottom <= height - 11.9, `${label}: tools fit vertically`);
+      if (hasTouch) {
+        // Replay representative native UI bounds based on the Android screenshot.
+        // Desktop Playwright does not render the platform selection controls.
+        const handles = [
+          { left: selection.left - 24, right: selection.left, top: selection.bottom, bottom: selection.bottom + 24 },
+          { left: selection.right, right: selection.right + 24, top: selection.bottom, bottom: selection.bottom + 24 }
+        ];
+        const menuTop = selection.top >= 64 ? selection.top - 52 : selection.bottom + 28;
+        const menu = { left: 12, right: width - 12, top: menuTop, bottom: menuTop + 40 };
+        assert.equal(
+          handles.some((handle) => overlaps(actions, handle)),
+          false,
+          `${label}: handles leave tools tappable`
+        );
+        assert.equal(overlaps(actions, menu), false, `${label}: native menu leaves tools tappable`);
+        await trigger.tap();
+      } else {
+        const gap = actions.top >= selection.bottom ? actions.top - selection.bottom : selection.top - actions.bottom;
+        assert.ok(Math.abs(gap - 8) < 1, `${label}: mouse selection retains its spacing`);
+        await trigger.click();
+      }
+      const panel = page.getByRole("dialog", { name: "Byte inspector" });
+      await panel.waitFor({ state: "visible" });
+      assert.equal(
+        await page.evaluate(() => getSelection().toString()),
+        "0x2f3",
+        `${label}: opening preserves selection`
+      );
+      await page.keyboard.press("Escape");
+      await trigger.waitFor({ state: "visible" });
+    }
+    await context.close();
+    console.log(`PASS ${browserName} ${width}x${height}: selection UI clearance, viewport edges and tool opening`);
+  }
+  assert.deepEqual(errors, [], "Browser exceptions");
+} finally {
+  await browser.close();
+}

--- a/tests/browser/support.mjs
+++ b/tests/browser/support.mjs
@@ -32,9 +32,9 @@ export function stubExternalResources(context) {
   });
 }
 
-export async function selectArticleText(page, text, selector = ".phile-body-pre") {
+export async function selectArticleText(page, text, selector = ".phile-body-pre", targetY) {
   await page.evaluate(
-    async ({ text, selector }) => {
+    async ({ text, selector, targetY }) => {
       const element = [...document.querySelectorAll(selector)].find((node) => node.textContent.includes(text));
       if (!element) throw new Error(`Missing article text: ${text}`);
       const start = element.textContent.indexOf(text);
@@ -52,10 +52,10 @@ export async function selectArticleText(page, text, selector = ".phile-body-pre"
         offset = next;
       }
       window.getSelection().removeAllRanges();
-      window.scrollBy(0, range.getBoundingClientRect().top - window.innerHeight / 3);
+      window.scrollBy(0, range.getBoundingClientRect().top - (targetY ?? window.innerHeight / 3));
       await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
       window.getSelection().addRange(range);
     },
-    { text, selector }
+    { text, selector, targetY }
   );
 }


### PR DESCRIPTION
## Summary

On Android Firefox, native text-selection handles could cover `[inspect]` and `[link]` because the entries appeared only 8px below the selected text. Touch entries now reserve 32px below the selection and 80px where the native action menu can appear, measured in viewport pixels so font scaling does not shrink the clearance.

The change also consolidates vertical viewport clamping and reuses the browser selection helper to test actual positions near both screen edges without synthetic pointer events.

## Scope

- [x] User-facing behavior
- [ ] Content
- [ ] Documentation
- [ ] Tooling or automation
- [ ] Build, CI, or deployment
- [x] Performance or maintenance

## Verification

- `pnpm lint`
- `pnpm test` — 82 tests passed
- `pnpm build` — includes configuration, Astro/TypeScript, formatting and boundary checks; 68 pages built
- Chromium and Firefox: `selection-placement`, `byte-inspector` and `fragment-citations` browser checks, including portrait/landscape layouts, screen edges, opening tools, copying and restoring selections
- Android Firefox device validation of the final 32px spacing

## Notes

The larger clearance applies to touch action entries. Automated tests replay representative native handle/menu bounds; Android's platform UI is not rendered by desktop Playwright.
