### PR TITLE
feat(volumes): add configurable animated volume artwork

### DIFF
--- a/README
+++ b/README
@@ -157,6 +157,35 @@ The public routes are:
 Per-volume behavior is configured in `entropic.config.ts` under `volumes`.
 Only the fields supplied for a volume override its generated defaults.
 
+Set `decoration` to `circuit`, `archive`, `study`, or `prism` for a themed header
+illustration. `life` keeps the original Game of Life frame and is the default
+for unconfigured volumes; `false` removes the decoration. For example:
+
+    volumes: {
+      0: { title: "Security Research", decoration: "circuit" },
+      1: { title: "Historical Philes", decoration: "archive" }
+    }
+
+The four illustrations also accept an options object:
+
+    decoration: {
+      kind: "study",
+      animated: true,
+      speed: 1,
+      calendar: { month: 12, day: 31 }
+    }
+
+`animated: false` keeps a static illustration. `speed` is a playback multiplier
+from 0.25 to 4: 0.5 is half speed, 2 is double speed. These optional settings
+default to `true` and `1`. `calendar` is only for `study` and defaults to December
+31; use a numeric month and a valid day (February 29 is supported). The original
+`life` frame uses the string shorthand. Every CPU transfer independently samples
+an 8-bit value, including 00 and FF; consecutive random values may repeat.
+
+The new illustrations remain visible without JavaScript. Their motion pauses
+offscreen, in hidden tabs, and when reduced motion is requested. Article
+headers keep their own Game of Life artwork.
+
 
 Redactions
 ----------

--- a/entropic.config.ts
+++ b/entropic.config.ts
@@ -363,11 +363,15 @@ export default {
   // Keys match src/content/philes/volume-<n>/; override only needed fields.
   // Optional: subtitle, listLabel, entryPrefix, entryLabel ("index"/"year"),
   // reverseEntryNumbers.
+  // decoration: "circuit" / "archive" / "study" / "prism" / "life" (default),
+  // or false to hide the header artwork. The four illustrations also accept
+  // { kind, animated?: boolean, speed?: 0.25..4 }; study adds calendar: { month, day }.
   // phileSort.by: "date"/"order"; direction: "asc"/"desc". postscript: text
   // lines, or [] to hide it.
   volumes: {
     "0": {
       title: "Security Research",
+      decoration: "circuit",
       listLabel: "Volume 0 - Security Research",
       phileSort: {
         by: "order",
@@ -383,6 +387,7 @@ export default {
     },
     "1": {
       title: "Historical Philes",
+      decoration: "archive",
       listLabel: "Volume 1 - Historical Philes",
       postscript: [
         "  ──[ EOF ]──────────────────────────────────────────────────────────────────//───",
@@ -400,6 +405,7 @@ export default {
     },
     "2": {
       title: "Year-End Wrap-ups",
+      decoration: { kind: "study", calendar: { month: 12, day: 31 } },
       listLabel: "Volume 2 - Year-End Wrap-ups",
       postscript: [
         "  ──[ 0x146 ]────────────────────────────────────────────────────────────────//───",
@@ -417,6 +423,7 @@ export default {
     },
     "3": {
       title: "Chromatic Philes",
+      decoration: "prism",
       listLabel: "Volume 3 - Chromatic Philes",
       postscript: [
         "  ──[ SGR ]──────────────────────────────────────────────────────────────────//───",

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -1,6 +1,6 @@
 import { cvePagePath } from "../features/cves/index.ts";
 import { defaultAppearance, defaultEffects, defaultHomeAsciiArt, defaultTextmode } from "./defaults.ts";
-import type { EntropicConfig, HomeSection, VolumeConfig } from "./types.ts";
+import type { EntropicConfig, HomeSection, ResolvedVolumeConfig, VolumeConfig } from "./types.ts";
 import { validateConfig } from "./validate.ts";
 
 /** Resolve nested groups explicitly; undefined inherits and arrays replace whole lists. */
@@ -108,14 +108,25 @@ export function resolveVolumeConfig(
   number: number,
   siteName: string,
   override: Partial<VolumeConfig> = {}
-): VolumeConfig {
-  return mergeDefined<VolumeConfig>(
+): ResolvedVolumeConfig {
+  const config = mergeDefined<VolumeConfig>(
     {
       title: `${siteName} Volume ${number}`,
       listLabel: `Volume ${number}`,
+      decoration: "life",
       phileSort: { by: "date", direction: "desc" },
       postscript: ["  ──[ EOF ]──────────────────────────────────────────────────────────────────//───"]
     },
     override
   );
+  const options = typeof config.decoration === "object" ? config.decoration : undefined;
+  return {
+    ...config,
+    decoration: {
+      kind: typeof config.decoration === "object" ? config.decoration.kind : config.decoration,
+      animated: options?.animated ?? true,
+      speed: options?.speed ?? 1,
+      calendar: (options?.kind === "study" ? options.calendar : undefined) ?? { month: 12, day: 31 }
+    }
+  };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -15,7 +15,11 @@ export type {
   HomeItem,
   HomeSection,
   ResearchRecognition,
+  ResolvedVolumeConfig,
+  VolumeCalendar,
   VolumeConfig,
+  VolumeDecoration,
+  VolumeDecorationOptions,
   VolumePhileSort
 } from "./types/content.ts";
 export type {

--- a/src/config/types/content.ts
+++ b/src/config/types/content.ts
@@ -25,15 +25,43 @@ export type VolumePhileSort = {
   readonly direction: "asc" | "desc";
 };
 
+export type VolumeDecoration = "circuit" | "archive" | "study" | "prism" | "life";
+
+export type VolumeCalendar = {
+  readonly month: number;
+  readonly day: number;
+};
+
+export type VolumeDecorationOptions = {
+  /** Keep the illustration visible while pausing its animation. Defaults to true. */
+  readonly animated?: boolean;
+  /** Playback multiplier, 0.25..4. Defaults to 1. */
+  readonly speed?: number;
+} & (
+  | { readonly kind: "study"; readonly calendar?: VolumeCalendar }
+  | { readonly kind: Exclude<VolumeDecoration, "study" | "life"> }
+);
+
 export type VolumeConfig = {
   readonly title: string;
   readonly subtitle?: string;
   readonly listLabel: string;
+  /** Header artwork. Defaults to life; false hides it. */
+  readonly decoration: VolumeDecoration | VolumeDecorationOptions | false;
   readonly postscript?: readonly string[];
   readonly entryPrefix?: string;
   readonly entryLabel?: "index" | "year";
   readonly reverseEntryNumbers?: boolean;
   readonly phileSort?: VolumePhileSort;
+};
+
+export type ResolvedVolumeConfig = Omit<VolumeConfig, "decoration"> & {
+  readonly decoration: {
+    readonly kind: VolumeDecoration | false;
+    readonly animated: boolean;
+    readonly speed: number;
+    readonly calendar: VolumeCalendar;
+  };
 };
 
 export type CveRecord = {

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -2,7 +2,7 @@ import { badgeArtworkPresetIds, calculateBadgeLayout, validateArtworkRotation } 
 import { appearanceCssVariables } from "../shared/textmode/core/css-vars.ts";
 import { safeUrl } from "../shared/urls.ts";
 import type { ResolvedConfig } from "./resolve.ts";
-import type { ArtworkSelection } from "./types.ts";
+import type { ArtworkSelection, VolumeConfig } from "./types.ts";
 
 /** TypeScript checks shapes; this boundary checks values and relationships. */
 export function validateConfig(config: ResolvedConfig): void {
@@ -61,6 +61,7 @@ export function validateConfig(config: ResolvedConfig): void {
   for (const number of Object.keys(config.volumes)) {
     if (!/^(0|[1-9]\d*)$/.test(number)) fail(`volumes.${number}`, "Use a non-negative volume number as the key.");
     integer(Number(number), `volumes.${number}`, 0);
+    validateVolumeDecoration(config.volumes[Number(number)]?.decoration, `volumes.${number}.decoration`);
   }
   const cveIds = new Set<string>();
   config.cves.records.forEach((record, index) => {
@@ -174,6 +175,29 @@ function validateArtwork(selection: ArtworkSelection): void {
     if (selection.presets.length === 0 || new Set(selection.presets).size !== selection.presets.length)
       fail(`${field}.presets`, "Provide a non-empty list of unique presets, or omit it to use all presets.");
     for (const id of selection.presets) preset(id, `${field}.presets`);
+  }
+}
+
+function validateVolumeDecoration(value: VolumeConfig["decoration"] | undefined, field: string): void {
+  if (value === undefined || value === false) return;
+  if (typeof value === "string") {
+    if (["circuit", "archive", "study", "prism", "life"].includes(value)) return;
+    fail(field, "Use circuit, archive, study, prism, life, false, or an illustration options object.");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(field, "Use an illustration options object.");
+  if (!["circuit", "archive", "study", "prism"].includes(value.kind))
+    fail(`${field}.kind`, "Use circuit, archive, study, or prism. The original Life frame uses the string life.");
+  if (value.animated !== undefined && typeof value.animated !== "boolean")
+    fail(`${field}.animated`, "Use true or false.");
+  if (value.speed !== undefined) bounded(value.speed, `${field}.speed`, 0.25, 4);
+  if ("calendar" in value && value.calendar !== undefined) {
+    if (value.kind !== "study") fail(`${field}.calendar`, "Only the study illustration has a calendar.");
+    const calendar = value.calendar;
+    if (!calendar || typeof calendar !== "object" || Array.isArray(calendar))
+      fail(`${field}.calendar`, "Provide a month and day.");
+    integer(calendar.month, `${field}.calendar.month`, 1, 12);
+    const monthDays = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    integer(calendar.day, `${field}.calendar.day`, 1, monthDays[calendar.month - 1]);
   }
 }
 

--- a/src/features/volumes/components/VolumeScreen.astro
+++ b/src/features/volumes/components/VolumeScreen.astro
@@ -1,4 +1,6 @@
 ---
+import { textmodeConfig, volumeConfig } from "@/config/server";
+import VolumeDecoration from "../decoration/VolumeDecoration.astro";
 import type { Volume } from "../model";
 import { renderVolumePre } from "../rendering/render";
 import Credits from "./Credits.astro";
@@ -9,14 +11,39 @@ type Props = {
 };
 
 const volume = Astro.props.volume;
-const volumeHtml = renderVolumePre(volume);
+const settings = volumeConfig(volume.number);
+const volumeHtml = renderVolumePre(volume, settings);
+const decoration = settings.decoration;
 ---
 
 <section class="textmode-wrap volume-wrap mt-line">
-  <pre class="textmode-pre volume-pre life-art" data-life-root set:html={volumeHtml} />
+  {
+    decoration.kind && decoration.kind !== "life" && (
+      <VolumeDecoration
+        {...decoration}
+        kind={decoration.kind}
+        number={volume.number}
+        columns={textmodeConfig.volumeRightColumn + 1}
+      />
+    )
+  }
+  <pre
+    class:list={["textmode-pre volume-pre", { "life-art": decoration.kind === "life" }]}
+    data-life-root={decoration.kind === "life" || undefined}
+    set:html={volumeHtml}
+  />
 </section>
 
 <Credits volume={volume} />
+
+<style>
+  @media (max-width: 760px) {
+    .volume-wrap {
+      /* Preserve fractional glyph advances so mobile zoom keeps the entire frame in view. */
+      text-rendering: geometricPrecision;
+    }
+  }
+</style>
 
 <script>
   import { initLifeArt } from "@/shared/textmode/life/client";

--- a/src/features/volumes/decoration/VolumeDecoration.astro
+++ b/src/features/volumes/decoration/VolumeDecoration.astro
@@ -1,0 +1,55 @@
+---
+import type { VolumeCalendar, VolumeDecoration } from "@/config/types";
+import Archive from "./art/Archive.astro";
+import Circuit from "./art/Circuit.astro";
+import Prism from "./art/Prism.astro";
+import Study from "./art/Study.astro";
+import "./styles.css";
+
+type Props = {
+  kind: Exclude<VolumeDecoration, "life">;
+  animated: boolean;
+  speed: number;
+  calendar: VolumeCalendar;
+  number: number;
+  columns: number;
+};
+
+const { kind, animated, speed, calendar, number, columns } = Astro.props;
+const Artwork = { circuit: Circuit, archive: Archive, study: Study, prism: Prism }[kind];
+---
+
+<div
+  class:list={["volume-decoration", `volume-decoration--${kind}`]}
+  style={`--decoration-columns: ${columns}; --decoration-speed: ${speed}`}
+  data-volume-decoration={kind}
+  data-static={!animated || undefined}
+  aria-hidden="true"
+>
+  <Artwork number={number} calendar={calendar} />
+</div>
+
+<script>
+  import { observeAnimationActivity } from "@/shared/browser/animation-activity";
+
+  for (const artwork of document.querySelectorAll<HTMLElement>("[data-volume-decoration]")) {
+    const svg = artwork.querySelector("svg");
+    if (!svg) continue;
+
+    const fitStroke = () => {
+      const scale = (svg.getBoundingClientRect().width / svg.viewBox.baseVal.width) * window.devicePixelRatio;
+      if (scale <= 0) return;
+      // Subpixel strokes can disappear in Firefox's crisp rasterizer after CSS zoom.
+      svg.style.setProperty("--decoration-stroke", `${scale < 1 ? 1.02 / scale : 1}px`);
+    };
+    new ResizeObserver(fitStroke).observe(svg);
+    window.addEventListener("resize", fitStroke, { passive: true });
+    fitStroke();
+
+    if (!artwork.hasAttribute("data-static")) {
+      observeAnimationActivity((active) => {
+        artwork.toggleAttribute("data-active", active);
+      }, artwork);
+    }
+  }
+</script>

--- a/src/features/volumes/decoration/art/Archive.astro
+++ b/src/features/volumes/decoration/art/Archive.astro
@@ -1,0 +1,50 @@
+---
+type Props = { number: number };
+const serial = Astro.props.number.toString().padStart(2, "0");
+// A repeating five-bit punched pattern keeps the tape editable and deterministic.
+const punches = [19, 7, 22, 3, 14, 25, 6, 21, 11, 28, 17, 26, 13, 5, 30, 9, 18, 27];
+---
+
+<svg viewBox="16 0 672 154" fill="none" stroke="currentColor" stroke-width="1" focusable="false">
+  <g class="decoration-muted">
+    <path d="M 123 139 H 139 M 131 131 V 147 M 617 20 H 629 M 623 14 V 26"></path>
+    <path d="M 558 36 H 597 V 119 H 564 M 566 44 H 605 V 127 H 565"></path>
+    <path d="M 167 148 H 211 M 176 144 V 152 M 192 144 V 152 M 208 144 V 152"></path>
+  </g>
+  <g transform="translate(364 4)">
+    <path class="decoration-paper" d="M 0 10 H 161 L 184 33 V 116 H 0 Z"></path>
+    <path d="M 161 10 V 33 H 184 M 16 28 H 122 M 16 42 H 81"></path>
+    <text x="16" y="69" stroke="none">PHILES / {serial}</text>
+    <path class="decoration-muted" stroke-dasharray="2 3" d="M 16 80 H 150 M 16 90 H 102"></path>
+    <g class="archive-stamp decoration-accent" transform="translate(108 72)">
+      <path d="M 0 0 H 76 V 28 H 0 Z M 3 3 H 73 V 25 H 3 Z"></path>
+      <text x="14" y="19" stroke="none">FILED</text>
+    </g>
+  </g>
+  <g transform="translate(155 83)">
+    <path
+      class="decoration-paper"
+      d="M 0 4 L 8 0 H 222 L 232 8 L 228 16 L 240 24 L 236 32 L 244 40 H 12 L 4 32 L 8 24 L -4 16 L 0 8 Z"></path>
+    <path class="decoration-muted" stroke-dasharray="1 11" stroke-width="3" d="M 11 6 H 219 M 15 34 H 235"></path>
+    {
+      punches.map((bits, column) => (
+        <g class:list={{ "decoration-accent": column % 5 === 2 }}>
+          {Array.from({ length: 5 }, (_, row) =>
+            bits & (1 << row) ? (
+              <rect
+                x={12 + column * 12 + row * 2}
+                y={11 + row * 4}
+                width="2"
+                height="2"
+                fill="currentColor"
+                stroke="none"
+              />
+            ) : null
+          )}
+        </g>
+      ))
+    }
+    <path class="archive-scan decoration-accent" d="M 10 7 H 16 M 13 9 V 31 M 10 33 H 16"></path>
+  </g>
+  <path class="decoration-muted" d="M 472 137 H 552 M 564 137 H 588 M 599 137 H 607"></path>
+</svg>

--- a/src/features/volumes/decoration/art/Circuit.astro
+++ b/src/features/volumes/decoration/art/Circuit.astro
@@ -1,0 +1,73 @@
+---
+const traces = [
+  "M 19 168 V 148 H 242 L 278 112 H 434",
+  "M 195 168 V 154 H 306 L 340 120 H 434",
+  "M 283 64 H 350 L 382 96 H 434",
+  "M 331 40 H 394 L 434 80",
+  "M 478 54 V 24 H 566 V 10",
+  "M 542 78 H 590 L 618 50 H 658",
+  "M 542 102 H 614 L 642 130 V 168",
+  "M 506 134 V 148 H 578 L 598 168"
+];
+---
+
+<svg data-circuit viewBox="16 0 672 168" fill="none" stroke="currentColor" stroke-width="1" focusable="false">
+  <g class="decoration-muted">
+    <path
+      d="M 227 168 V 160 H 286 L 326 120 M 295 56 H 356 L 388 88 H 426 M 486 46 V 32 H 574 V 16 M 550 86 H 594 L 622 58 H 664 M 622 110 L 650 138 V 160"
+    ></path>
+    <path d="M 404 42 H 412 M 408 38 V 46 M 628 22 H 636 M 632 18 V 26 M 365 142 H 373 M 369 138 V 146"></path>
+    {
+      Array.from({ length: 5 }, (_, row) => (
+        <path stroke-dasharray="1 5" d={`M 363 ${60 + row * 6} h 24 M 554 ${118 + row * 6} h 18`} />
+      ))
+    }
+  </g>
+  <g>{traces.map((d) => <path d={d} />)}</g>
+  <g class="decoration-accent">
+    <path class="circuit-signal circuit-signal--input" pathLength="100" d={traces[0]}></path>
+    <path class="circuit-signal circuit-signal--return" pathLength="100" d={traces[6]}></path>
+    <path class="circuit-core" d="M 462 70 H 510 V 118 H 462 Z M 470 78 H 502 V 110 H 470 Z"></path>
+  </g>
+  <path class="circuit-package" d="M 442 62 H 534 V 126 H 442 Z M 434 54 H 542 V 134 H 434 Z"></path>
+  {Array.from({ length: 7 }, (_, i) => <path d={`M ${450 + i * 12} 46 v 8 m 0 80 v 8`} />)}
+  {Array.from({ length: 5 }, (_, i) => <path d={`M 426 ${70 + i * 12} h 8 m 108 0 h 8`} />)}
+  <g class="decoration-paper">
+    <circle cx="283" cy="64" r="3"></circle><circle cx="331" cy="40" r="3"></circle>
+    <circle cx="566" cy="10" r="3"></circle><circle cx="658" cy="50" r="3"></circle>
+  </g>
+  <text data-circuit-register x="478" y="100" stroke="none">00</text>
+  <text data-circuit-bus class="decoration-muted" x="220" y="122" stroke="none">0x00</text>
+</svg>
+
+<script>
+  const randomByte = () =>
+    Math.floor(Math.random() * 256)
+      .toString(16)
+      .toUpperCase()
+      .padStart(2, "0");
+
+  for (const circuit of document.querySelectorAll("[data-circuit]")) {
+    const register = circuit.querySelector("[data-circuit-register]");
+    const bus = circuit.querySelector("[data-circuit-bus]");
+    const input = circuit.querySelector(".circuit-signal--input");
+    const output = circuit.querySelector(".circuit-signal--return");
+    if (!register || !bus || !input || !output) continue;
+
+    let byte = "";
+    const transmit = () => {
+      byte = randomByte();
+      bus.textContent = `0x${byte}`;
+    };
+    const receive = () => {
+      register.textContent = byte;
+    };
+
+    // CSS is the shared clock: pausing the signals also freezes the readouts.
+    register.textContent = randomByte();
+    transmit();
+    input.addEventListener("animationiteration", transmit);
+    output.addEventListener("animationstart", receive);
+    output.addEventListener("animationiteration", receive);
+  }
+</script>

--- a/src/features/volumes/decoration/art/Prism.astro
+++ b/src/features/volumes/decoration/art/Prism.astro
@@ -1,0 +1,41 @@
+---
+const beams = [
+  { color: "prism-red", path: "M 437 77 L 617 43" },
+  { color: "prism-yellow", path: "M 444 83 L 627 65" },
+  { color: "decoration-accent", path: "M 451 90 H 637" },
+  { color: "prism-cyan", path: "M 457 97 L 629 116" },
+  { color: "prism-magenta", path: "M 464 104 L 618 139" }
+];
+const incident = "M 190 92 H 379 L 437 77";
+---
+
+<svg viewBox="16 10 672 168" fill="none" stroke="currentColor" stroke-width="1" focusable="false">
+  <g class="decoration-muted">
+    <path d="M 239 146 H 651 M 429 14 V 22 M 429 158 V 170 M 251 102 H 267 M 259 94 V 110 M 644 20 H 656 M 650 14 V 26"
+    ></path>
+    <path stroke-dasharray="2 6" d="M 339 158 H 557 M 605 77 V 143"></path>
+    <path d="M 349 143 L 421 161 L 496 147"></path>
+    <path stroke-dasharray="1 5" d="M 561 152 H 591 M 565 158 H 595 M 569 164 H 599"></path>
+  </g>
+  <g class="prism-beams">
+    {beams.map(({ color, path }) => <path d={path} class={color} />)}
+  </g>
+  <path d={incident}></path>
+  <path class="decoration-muted" d="M 211 100 H 376"></path>
+  <g>
+    <path d="M 415 27 L 351 140 H 479 Z"></path>
+    <path
+      class="decoration-muted"
+      d="M 415 27 L 449 43 L 513 140 H 479 M 351 140 L 385 153 H 513 V 140 M 449 43 L 385 153"></path>
+    <path class="decoration-muted" stroke-dasharray="3 4" d="M 415 27 L 385 153 M 449 43 L 479 140"></path>
+    <path class="decoration-accent" d="M 405 45 L 363 120 M 491 125 L 459 69"></path>
+  </g>
+  <path class="prism-signal" pathLength="100" d={incident}></path>
+  {
+    beams.map(({ color, path }) => (
+      <path class:list={["prism-signal", "prism-signal--split", color]} pathLength="100" d={path} />
+    ))
+  }
+  <text class="decoration-muted" x="271" y="83" stroke="none">*</text>
+  <text class="decoration-muted" x="560" y="36" stroke="none">r / g / b</text>
+</svg>

--- a/src/features/volumes/decoration/art/Study.astro
+++ b/src/features/volumes/decoration/art/Study.astro
@@ -1,0 +1,64 @@
+---
+import type { VolumeCalendar } from "@/config/types";
+type Props = { calendar: VolumeCalendar };
+const { month, day } = Astro.props.calendar;
+const monthLabel = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"][month - 1];
+---
+
+<svg viewBox="16 16 672 124" fill="none" stroke="currentColor" stroke-width="1" focusable="false">
+  <g class="decoration-muted">
+    <path d="M 233 120 H 669 M 247 126 H 310 M 493 126 H 659"></path>
+    <path stroke-dasharray="1 5" d="M 255 132 H 286 M 577 132 H 608"></path>
+  </g>
+  <g>
+    <path
+      class="decoration-paper"
+      d="M 257 103 H 392 V 119 H 257 Z M 264 85 H 378 V 103 H 264 Z M 278 71 H 385 V 85 H 278 Z"></path>
+    <path
+      d="M 263 108 H 383 M 263 114 H 379 M 273 90 H 369 M 273 97 H 365 M 285 76 H 377 M 285 81 H 366"
+      class="decoration-muted"></path>
+    <path d="M 257 103 H 392 M 264 85 H 378 M 278 71 H 385" class="decoration-accent"></path>
+    <path d="M 337 86 V 103 L 344 97 L 351 103 V 86" class="decoration-paper decoration-accent"></path>
+  </g>
+  <g class="study-steam decoration-muted">
+    <path d="M 421 64 C 411 56 432 52 423 42"></path>
+  </g>
+  <g class="study-steam study-steam--late decoration-muted">
+    <path d="M 441 62 C 432 55 451 49 444 36"></path>
+  </g>
+  <g>
+    <ellipse class="decoration-muted" cx="434" cy="114" rx="37" ry="5"></ellipse>
+    <path class="decoration-muted" d="M 416 115 Q 434 119 452 115"></path>
+    <path class="decoration-paper" d="M 453 83 H 460 C 478 83 478 103 460 105 H 451 Z"></path>
+    <path class="decoration-muted" d="M 453 88 H 460 C 471 88 471 98 460 100 H 452"></path>
+    <path class="decoration-paper" d="M 410 77 L 411 100 Q 412 113 432 113 Q 452 113 453 100 L 454 77 Z"></path>
+    <ellipse class="decoration-paper" cx="432" cy="77" rx="22" ry="4"></ellipse>
+    <path class="decoration-muted" d="M 417 78 Q 432 75 447 78 M 416 87 L 417 99 Q 417 103 421 105"></path>
+  </g>
+  <g>
+    <path
+      class="decoration-paper"
+      d="M 533 106 C 528 90 540 78 558 77 C 579 75 596 85 598 99 C 600 111 589 118 572 118 H 529 Q 521 118 521 112 Z"
+    ></path>
+    <path class="decoration-muted" d="M 559 81 Q 563 84 563 88 M 573 84 Q 577 87 576 91"></path>
+    <path class="decoration-paper" d="M 510 109 Q 499 108 498 114 Q 497 118 505 118 H 531 Q 539 118 537 112 Z"></path>
+    <path
+      class="decoration-paper"
+      d="M 503 96 L 501 80 L 514 87 Q 523 84 533 89 L 545 83 L 543 100 C 540 110 530 114 518 111 C 507 111 502 105 503 96 Z"
+    ></path>
+    <path class="decoration-muted" d="M 507 88 L 508 94 M 539 90 L 537 95 M 505 115 H 511"></path>
+    <path d="M 510 99 Q 514 103 519 100 M 527 101 Q 531 105 536 101 M 521 104 L 524 105 L 522 107"></path>
+    <path class="decoration-muted" d="M 505 102 L 497 100 M 505 106 L 497 107"></path>
+    <path d="M 586 94 C 599 96 599 111 583 114 H 562 C 549 114 546 107 552 102 C 558 97 567 102 562 107"></path>
+    <text x="518" y="69" stroke="none" class="study-dream">z</text>
+    <text x="538" y="55" stroke="none" class="study-dream study-dream--late">z</text>
+  </g>
+  <g transform="translate(610 66)">
+    <path class="decoration-muted" d="M 42 6 L 53 54 H -2"></path>
+    <path class="decoration-paper" d="M 4 6 H 42 L 36 52 H -2 Z"></path>
+    <path class="decoration-muted" d="M 1 26 H 39"></path>
+    <path class="decoration-accent" d="M 10 5 V 1 H 14 V 11 M 30 5 V 1 H 34 V 11"></path>
+    <text class="decoration-muted" x="9" y="23" stroke="none">{monthLabel}</text>
+    <text x="12" y="44" stroke="none">{String(day).padStart(2, "0")}</text>
+  </g>
+</svg>

--- a/src/features/volumes/decoration/styles.css
+++ b/src/features/volumes/decoration/styles.css
@@ -1,0 +1,207 @@
+.volume-decoration {
+  --decoration-cycle: calc(6s / var(--decoration-speed, 1));
+  /* ch follows the bitmap font's rounded advance under mobile CSS zoom. */
+  width: calc(var(--decoration-columns) * 1ch);
+  color: var(--fg);
+  font-family: var(--text-font);
+  font-size: var(--text-size);
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+}
+
+.volume-decoration svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+  shape-rendering: crispEdges;
+  stroke-width: var(--decoration-stroke, 1px);
+}
+
+.volume-decoration text {
+  fill: currentColor;
+  /* ViewBox coordinates use the default 8 x 14 text grid. */
+  font-size: 14px;
+  text-rendering: optimizeSpeed;
+}
+
+.volume-decoration--circuit {
+  --decoration-cycle: calc(2.4s / var(--decoration-speed, 1));
+  margin-bottom: calc(var(--text-size) * -0.5);
+}
+
+.volume-decoration .decoration-muted {
+  opacity: 0.45;
+}
+
+.volume-decoration .decoration-accent {
+  color: var(--link);
+}
+
+.volume-decoration .decoration-paper {
+  fill: var(--bg);
+}
+
+.volume-decoration .circuit-signal,
+.volume-decoration .prism-signal {
+  stroke-dasharray: 4 104;
+  animation: volume-transfer var(--decoration-cycle) linear infinite;
+}
+
+.volume-decoration .circuit-signal--return,
+.volume-decoration .prism-signal--split {
+  opacity: 0;
+  animation-delay: calc(var(--decoration-cycle) / 2);
+}
+
+.volume-decoration .circuit-core {
+  animation: volume-circuit-latch var(--decoration-cycle) linear infinite;
+}
+
+.volume-decoration .archive-scan {
+  shape-rendering: geometricPrecision;
+  animation: volume-archive-scan var(--decoration-cycle) linear calc(var(--decoration-cycle) / -6) infinite;
+}
+
+.volume-decoration .archive-stamp {
+  animation: volume-archive-stamp var(--decoration-cycle) linear calc(var(--decoration-cycle) / -6) infinite;
+}
+
+.volume-decoration .study-steam {
+  /* Moving strokes interpolate between pixels; the stationary artwork stays crisp. */
+  shape-rendering: geometricPrecision;
+  animation: volume-steam calc(5s / var(--decoration-speed, 1)) linear calc(-1s / var(--decoration-speed, 1)) infinite;
+}
+
+.volume-decoration .study-steam--late {
+  animation-delay: calc(-3.5s / var(--decoration-speed, 1));
+}
+
+.volume-decoration .study-dream {
+  opacity: 0.35;
+  animation: volume-dream var(--decoration-cycle) ease-in-out infinite;
+}
+
+.volume-decoration .study-dream--late {
+  animation-delay: calc(var(--decoration-cycle) / -2);
+}
+
+.volume-decoration .prism-beams {
+  opacity: 0.65;
+}
+
+.volume-decoration .prism-red {
+  color: var(--ansi-red);
+}
+
+.volume-decoration .prism-yellow {
+  color: var(--ansi-yellow);
+}
+
+.volume-decoration .prism-cyan {
+  color: var(--ansi-cyan);
+}
+
+.volume-decoration .prism-magenta {
+  color: var(--ansi-magenta);
+}
+
+/* A complete static illustration is also the no-JS and reduced-motion state. */
+.volume-decoration:not([data-active]) * {
+  animation-play-state: paused;
+}
+
+@keyframes volume-transfer {
+  0% {
+    stroke-dashoffset: 4;
+    opacity: 1;
+  }
+  48% {
+    stroke-dashoffset: -100;
+    opacity: 1;
+  }
+  50%,
+  100% {
+    stroke-dashoffset: -100;
+    opacity: 0;
+  }
+}
+
+@keyframes volume-archive-scan {
+  0% {
+    transform: translateX(0);
+    opacity: 0;
+  }
+  6%,
+  75% {
+    opacity: 1;
+  }
+  82%,
+  100% {
+    transform: translateX(204px);
+    opacity: 0;
+  }
+}
+
+@keyframes volume-archive-stamp {
+  0%,
+  72%,
+  100% {
+    opacity: 0.45;
+  }
+  84%,
+  92% {
+    opacity: 1;
+  }
+}
+
+@keyframes volume-circuit-latch {
+  0%,
+  42%,
+  100% {
+    opacity: 0.4;
+  }
+  50%,
+  60% {
+    opacity: 1;
+  }
+}
+
+@keyframes volume-steam {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  15%,
+  70% {
+    opacity: 0.5;
+  }
+  100% {
+    transform: translateY(-16px);
+    opacity: 0;
+  }
+}
+
+@keyframes volume-dream {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.65;
+  }
+}
+
+@media (max-width: 760px) {
+  .volume-decoration svg {
+    /* No-JS fallback; the client refines this to a physical pixel for the actual display. */
+    stroke-width: var(--decoration-stroke, max(1px, calc(1.02px / min(var(--mobile-scale), var(--fit-scale)))));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .volume-decoration[data-active] * {
+    animation-play-state: paused;
+  }
+}

--- a/src/features/volumes/rendering/render.ts
+++ b/src/features/volumes/rendering/render.ts
@@ -1,46 +1,57 @@
 import { textmodeConfig, volumeConfig } from "@/config/server";
+import type { ResolvedVolumeConfig } from "@/config/types";
 import type { PhileCredit } from "@/features/philes";
 import { cellWidth, escapeHtml, link, padCells, textHtml, truncateCells } from "@/shared/textmode";
 import { lifeFrameLineHtml, lifeFrameLines } from "@/shared/textmode/life";
 import { creditAuthorWidth } from "../credits/presentation";
 import type { Volume } from "../model";
-import { volumeTitle } from "./labels";
 
 const artIndent = textmodeConfig.volumeArtIndent;
 const tocRightColumn = textmodeConfig.volumeRightColumn;
 const tocInnerWidth = tocRightColumn - 1;
 const tocContentWidth = tocInnerWidth - 2;
 
-export function renderVolumePre(volume: Volume): string {
-  const toc = renderToc(volume);
-  const postscript = volumeConfig(volume.number).postscript ?? [];
+export function renderVolumePre(volume: Volume, config = volumeConfig(volume.number)): string {
+  const toc = renderToc(volume, config);
+  const postscript = config.postscript ?? [];
 
-  return `\n${toc}\n\n${textHtml(postscript.join("\n"))}\n`;
+  return `${config.decoration.kind === "life" ? "\n" : ""}${toc}\n\n${textHtml(postscript.join("\n"))}\n`;
 }
 
-function renderToc(volume: Volume): string {
-  const config = volumeConfig(volume.number);
-  const title = config.subtitle ? `${volumeTitle(volume)} - ${config.subtitle}` : volumeTitle(volume);
-  const lifeLines = lifeFrameLines();
-  const entryLabelWidth = Math.max(
-    ...volume.philes.map((phile, index) => cellWidth(entryLabel(volume, index, phile.data.title, phile.data.date)))
-  );
+function renderToc(volume: Volume, config: ResolvedVolumeConfig): string {
+  const title = config.subtitle ? `${config.title} - ${config.subtitle}` : config.title;
+  const entries = volume.philes.map((phile, index) => ({
+    phile,
+    index,
+    label: entryLabel(volume, index, phile.data.title, phile.data.date, config)
+  }));
+  const entryLabelWidth = Math.max(0, ...entries.map(({ label }) => cellWidth(label)));
   const badgeWidth = Math.max(
     0,
     ...volume.philes.map((phile) => (phile.credits.length > 1 ? String(phile.credits.length - 1).length + 4 : 0))
   );
   const lines = [
-    ...lifeLines.slice(0, 14).map((_, row) => `${" ".repeat(artIndent)}${lifeFrameLineHtml(row)}`),
-    `┌${"─".repeat(artIndent - 1)}${lifeFrameLineHtml(14)}`,
-    `│ ${pad(title, artIndent - 2)}${lifeFrameLineHtml(15)}`,
-    `│ ${pad("                                    CONTENTS", artIndent - 2)}${lifeFrameLineHtml(16)}`,
+    ...(config.decoration.kind === "life"
+      ? [
+          ...lifeFrameLines()
+            .slice(0, 14)
+            .map((_, row) => `${" ".repeat(artIndent)}${lifeFrameLineHtml(row)}`),
+          `┌${"─".repeat(artIndent - 1)}${lifeFrameLineHtml(14)}`,
+          `│ ${padCells(title, artIndent - 2)}${lifeFrameLineHtml(15)}`,
+          `│ ${padCells("                                    CONTENTS", artIndent - 2)}${lifeFrameLineHtml(16)}`
+        ]
+      : [
+          `┌${"─".repeat(tocInnerWidth)}┐`,
+          frameLine(title),
+          frameLine(`${" ".repeat(Math.max(0, Math.floor((tocContentWidth - 8) / 2)))}CONTENTS`)
+        ]),
     frameLine(""),
-    ...volume.philes.map((phile, index) =>
+    ...entries.map(({ phile, index, label }) =>
       renderTocLine(
-        volume,
+        config,
         index,
+        label,
         phile.data.title,
-        phile.data.date,
         phile.route.href,
         phile.credits,
         entryLabelWidth,
@@ -55,17 +66,15 @@ function renderToc(volume: Volume): string {
 }
 
 function renderTocLine(
-  volume: Volume,
+  config: ResolvedVolumeConfig,
   index: number,
+  label: string,
   title: string,
-  date: Date,
   href: string,
   credits: readonly PhileCredit[],
   entryLabelWidth: number,
   badgeWidth: number
 ): string {
-  const config = volumeConfig(volume.number);
-  const label = entryLabel(volume, index, title, date);
   const prefix = `${padCells(label, entryLabelWidth)}  `;
   const entryTitle = config.entryLabel === "year" ? title.replace(/^\d{4}\s+/, "") : title;
   const author = credits[0]?.name ?? "";
@@ -85,8 +94,7 @@ function renderTocLine(
   return `│ ${escapeHtml(prefix)}${titleLink} ${dots}${tailHtml} │`;
 }
 
-function entryLabel(volume: Volume, index: number, title: string, date: Date): string {
-  const config = volumeConfig(volume.number);
+function entryLabel(volume: Volume, index: number, title: string, date: Date, config: ResolvedVolumeConfig): string {
   const entryNumber = config.reverseEntryNumbers ? volume.philes.length - index - 1 : index;
   const titleYear = title.match(/^\d{4}\b/)?.[0];
 
@@ -95,10 +103,6 @@ function entryLabel(volume: Volume, index: number, title: string, date: Date): s
     : `${config.entryPrefix ?? volume.number}.${entryNumber}`;
 }
 
-function pad(input: string, width: number): string {
-  return padCells(input, width);
-}
-
 function frameLine(input: string): string {
-  return `│ ${pad(input, tocContentWidth)} │`;
+  return `│ ${padCells(input, tocContentWidth)} │`;
 }

--- a/tests/browser/animations.mjs
+++ b/tests/browser/animations.mjs
@@ -57,7 +57,7 @@ try {
   );
   console.log(`PASS ${browserName}: live motion preferences, responsive particle counts, page hide/show`);
 
-  await page.goto(new URL("/volume/0/", baseUrl).href);
+  await page.goto(new URL("/volume/3/ansi-ink-phile/", baseUrl).href);
   await page.locator(".life-grid").waitFor();
   await settleTextLayout(page);
   const readLifeOffset = () =>

--- a/tests/browser/run.mjs
+++ b/tests/browser/run.mjs
@@ -1,5 +1,7 @@
 await import("./textmode-fit.mjs");
 await import("./animations.mjs");
+await import("./volume-decorations.mjs");
+await import("./volume-rendering.mjs");
 await import("./particle-activity.mjs");
 await import("./site-badges.mjs");
 await import("./badge-copy.mjs");

--- a/tests/browser/volume-decorations.mjs
+++ b/tests/browser/volume-decorations.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { baseUrl, browserName, launchBrowser, settleTextLayout } from "./support.mjs";
+
+const browser = await launchBrowser();
+const errors = [];
+const themes = ["circuit", "archive", "study", "prism"];
+
+try {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 }, reducedMotion: "no-preference" });
+  page.setDefaultTimeout(15000);
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  for (const [number, theme] of themes.entries()) {
+    await page.goto(new URL(`/volume/${number}/`, baseUrl).href);
+    // Let the page finish its lazy startup before a later navigation can cancel imports.
+    await page.locator(".ascii-particles span").first().waitFor({ state: "attached" });
+    await settleTextLayout(page);
+    const artwork = page.locator("[data-volume-decoration]");
+    assert.equal(await artwork.getAttribute("data-volume-decoration"), theme);
+    assert.equal(await artwork.getAttribute("aria-hidden"), "true");
+    await page.waitForFunction(() => document.querySelector("[data-volume-decoration]").hasAttribute("data-active"));
+    const animation = () =>
+      page.evaluate(() =>
+        document
+          .querySelector("[data-volume-decoration]")
+          .getAnimations({ subtree: true })
+          .map((item) => ({
+            time: item.currentTime,
+            state: item.playState
+          }))
+      );
+    assert.ok(
+      (await animation()).some(({ state }) => state === "running"),
+      `${theme}: visible motion`
+    );
+    if (theme === "circuit") await assertCircuitTransfer(page);
+
+    const links = await page.locator(".volume-pre a").evaluateAll((items) => items.map((item) => item.href));
+    assert.ok(links.length > 0);
+    for (const width of [320, 390, 760, 1280]) {
+      await page.setViewportSize({ width, height: 844 });
+      await settleTextLayout(page);
+      const layout = await page.evaluate(() => {
+        const art = document.querySelector("[data-volume-decoration]").getBoundingClientRect();
+        const toc = document.querySelector(".volume-pre").getBoundingClientRect();
+        const text = document.querySelector(".volume-pre").firstChild;
+        const frame = new Range();
+        frame.setStart(text, 0);
+        frame.setEnd(text, text.textContent.indexOf("\n"));
+        const link = document.querySelector(".volume-pre a").getBoundingClientRect();
+        return {
+          overflow: document.documentElement.scrollWidth - innerWidth,
+          left: art.left,
+          right: art.right,
+          width: art.width,
+          tocWidth: toc.width,
+          frameWidth: frame.getBoundingClientRect().width,
+          bottom: art.bottom,
+          linkTop: link.top,
+          height: art.height
+        };
+      });
+      assert.ok(layout.overflow <= 1 && layout.left >= -1 && layout.right <= width + 1, `${theme}: fits ${width}px`);
+      assert.ok(layout.width <= layout.tocWidth + 1, `${theme}: stays within the contents width`);
+      assert.ok(Math.abs(layout.width - layout.frameWidth) <= 1, `${theme}: follows the actual font advance`);
+      assert.ok(layout.bottom < layout.linkTop, `${theme}: never covers the links`);
+      if (width <= 390) assert.ok(layout.height < 110, `${theme}: compact mobile height`);
+    }
+    assert.deepEqual(await page.locator(".volume-pre a").evaluateAll((items) => items.map((item) => item.href)), links);
+
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.waitForFunction(() => !document.querySelector("[data-volume-decoration]").hasAttribute("data-active"));
+    const reduced = await animation();
+    assert.ok(reduced.length > 0 && reduced.every(({ state }) => state === "paused"), `${theme}: reduced motion`);
+    await page.waitForTimeout(120);
+    assert.deepEqual(await animation(), reduced, `${theme}: reduced motion has no frame changes`);
+    if (theme === "circuit") await assertCircuitFrozen(page);
+    await page.emulateMedia({ reducedMotion: "no-preference" });
+    await page.waitForFunction(() => document.querySelector("[data-volume-decoration]").hasAttribute("data-active"));
+
+    await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+    await page.waitForFunction(() => !document.querySelector("[data-volume-decoration]").hasAttribute("data-active"));
+    assert.ok(
+      (await animation()).every(({ state }) => state === "paused"),
+      `${theme}: pagehide pauses`
+    );
+    if (theme === "circuit") await assertCircuitFrozen(page);
+    await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true })));
+    await page.waitForFunction(() => document.querySelector("[data-volume-decoration]").hasAttribute("data-active"));
+    console.log(`PASS ${browserName}: ${theme} layout, motion preferences, page lifecycle`);
+  }
+
+  await page.goto(new URL("/volume/0/", baseUrl).href);
+  await page.locator(".ascii-particles span").first().waitFor({ state: "attached" });
+  await page.waitForFunction(() => document.querySelector("[data-volume-decoration]").hasAttribute("data-active"));
+  await page.evaluate(() => {
+    // Keep a real scroll available even when the volume has only a few articles.
+    document.body.style.minHeight = "200vh";
+    window.scrollTo(0, document.documentElement.scrollHeight);
+  });
+  await page.waitForFunction(() => !document.querySelector("[data-volume-decoration]").hasAttribute("data-active"));
+  assert.ok(
+    await page
+      .locator("[data-volume-decoration]")
+      .evaluate((element) => element.getAnimations({ subtree: true }).every((item) => item.playState === "paused"))
+  );
+  await assertCircuitFrozen(page);
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await page.waitForFunction(() => document.querySelector("[data-volume-decoration]").hasAttribute("data-active"));
+  await assertCircuitTransfer(page);
+
+  await assertRandomBytes(browser);
+
+  const staticPage = await browser.newPage({ javaScriptEnabled: false, viewport: { width: 390, height: 844 } });
+  for (const [number, theme] of themes.entries()) {
+    await staticPage.goto(new URL(`/volume/${number}/`, baseUrl).href);
+    assert.equal(await staticPage.locator("[data-volume-decoration] svg").count(), 1);
+    assert.equal(await staticPage.locator("[data-volume-decoration][data-active]").count(), 0);
+    assert.ok(await staticPage.locator(".volume-pre a").first().isVisible(), `${theme}: usable without JavaScript`);
+    assert.ok(
+      await staticPage
+        .locator("[data-volume-decoration]")
+        .evaluate((element) => element.getAnimations({ subtree: true }).every((item) => item.playState === "paused"))
+    );
+  }
+  assert.deepEqual(errors, []);
+  console.log(`PASS ${browserName}: offscreen pause and static no-JavaScript artwork`);
+} finally {
+  await browser.close();
+}
+
+function circuitReadouts(page) {
+  return page.locator("[data-circuit-register], [data-circuit-bus]").allTextContents();
+}
+
+async function assertCircuitTransfer(page) {
+  const [, busBefore] = await circuitReadouts(page);
+  await page.waitForFunction(
+    (previous) => document.querySelector("[data-circuit-bus]").textContent !== previous,
+    busBefore
+  );
+  const [registerDuring, busDuring] = await circuitReadouts(page);
+  assert.match(registerDuring, /^[0-9A-F]{2}$/);
+  assert.match(busDuring, /^0x[0-9A-F]{2}$/);
+  await page.waitForFunction(
+    (byte) => document.querySelector("[data-circuit-register]").textContent === byte,
+    busDuring.slice(2)
+  );
+  const [registerAfter, busAfter] = await circuitReadouts(page);
+  assert.equal(registerAfter, busAfter.slice(2), "CPU receives the byte shown on the bus");
+}
+
+async function assertRandomBytes(browser) {
+  const page = await browser.newPage({ reducedMotion: "no-preference" });
+  page.setDefaultTimeout(15000);
+  page.on("pageerror", (error) => errors.push(error.message));
+  try {
+    // Constant random sources cover both endpoints without probabilistic assertions.
+    await page.addInitScript(() => {
+      Math.random = () => 0;
+    });
+    await page.goto(new URL("/volume/0/", baseUrl).href);
+    await page.locator("[data-volume-decoration][data-active]").waitFor({ state: "attached" });
+    assert.deepEqual(await circuitReadouts(page), ["00", "0x00"]);
+    for (const [random, byte] of [
+      [1 - Number.EPSILON, "FF"],
+      [0.25, "40"],
+      [0, "00"]
+    ]) {
+      await page.evaluate((value) => {
+        Math.random = () => value;
+      }, random);
+      await page.waitForFunction((expected) => {
+        return (
+          document.querySelector("[data-circuit-register]").textContent === expected &&
+          document.querySelector("[data-circuit-bus]").textContent === `0x${expected}`
+        );
+      }, byte);
+    }
+    const duration = await page
+      .locator(".circuit-signal--input")
+      .evaluate((signal) => signal.getAnimations()[0].effect.getTiming().duration);
+    await page.waitForTimeout(duration + 100);
+    assert.deepEqual(await circuitReadouts(page), ["00", "0x00"], "Independent random bytes may repeat");
+    console.log(`PASS ${browserName}: random CPU bytes include 00, FF, and consecutive repeats`);
+  } finally {
+    await page.close();
+  }
+}
+
+async function assertCircuitFrozen(page) {
+  const before = await circuitReadouts(page);
+  const duration = await page
+    .locator(".circuit-signal--input")
+    .evaluate((signal) => signal.getAnimations()[0].effect.getTiming().duration);
+  await page.waitForTimeout(duration + 100);
+  assert.deepEqual(
+    await circuitReadouts(page),
+    before,
+    "Paused circuit readouts stay frozen for a complete transfer cycle"
+  );
+}

--- a/tests/browser/volume-rendering.mjs
+++ b/tests/browser/volume-rendering.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import sharp from "sharp";
+import { baseUrl, browserName, launchBrowser, settleTextLayout } from "./support.mjs";
+
+const browser = await launchBrowser();
+try {
+  const page = await browser.newPage({
+    viewport: { width: 1280, height: 800 },
+    deviceScaleFactor: 1,
+    reducedMotion: "no-preference"
+  });
+  await page.goto(new URL("/volume/0/", baseUrl).href);
+  await page.locator(".ascii-particles span").first().waitFor({ state: "attached" });
+  for (const width of [1280, 390, 320, 1280]) {
+    await page.setViewportSize({ width, height: 800 });
+    await settleTextLayout(page);
+    await assertCrispEdges(page);
+  }
+  console.log(`PASS ${browserName}: crisp, complete hairlines at desktop and mobile widths`);
+
+  await page.goto(new URL("/volume/2/", baseUrl).href);
+  await page.locator(".ascii-particles span").first().waitFor({ state: "attached" });
+  await page.waitForFunction(() => document.querySelector("[data-volume-decoration]").hasAttribute("data-active"));
+  const motions = await page.locator(".study-steam").evaluateAll((steams) =>
+    steams.map((steam) => {
+      const animation = steam.getAnimations()[0];
+      animation.pause();
+      let previous;
+      let heldFrames = 0;
+      let longestHold = 0;
+      const positions = new Set();
+      // Sample browser-computed frames within the active movement, independently of machine load.
+      for (let time = 600; time < 2200; time += 1000 / 60) {
+        animation.currentTime = time;
+        const transform = getComputedStyle(steam).transform;
+        positions.add(transform);
+        heldFrames = transform === previous ? heldFrames + 1 : 0;
+        longestHold = Math.max(longestHold, heldFrames);
+        previous = transform;
+      }
+      animation.play();
+      return { positions: positions.size, longestHoldMs: (longestHold * 1000) / 60 };
+    })
+  );
+  assert.ok(
+    motions.length > 0 && motions.every((motion) => motion.positions > 80 && motion.longestHoldMs < 50),
+    `Steam jumps between held frames: ${JSON.stringify(motions)}`
+  );
+  console.log(`PASS ${browserName}: continuous steam movement without stepped holds`);
+} finally {
+  await browser.close();
+}
+
+async function assertCrispEdges(page) {
+  // Inspect all four edges: a hairline must neither blur nor vanish under mobile zoom.
+  const reference = await page.locator(".circuit-package").evaluate((path) => {
+    const box = path.getBBox();
+    const svg = path.ownerSVGElement;
+    const rect = svg.getBoundingClientRect();
+    const view = svg.viewBox.baseVal;
+    const rgb = (value) =>
+      value
+        .match(/[\d.]+/g)
+        .slice(0, 3)
+        .map(Number);
+    const points = [
+      [box.x, box.y + box.height * 0.43, "vertical"],
+      [box.x + box.width, box.y + box.height * 0.43, "vertical"],
+      [box.x + box.width * 0.43, box.y, "horizontal"],
+      [box.x + box.width * 0.43, box.y + box.height, "horizontal"]
+    ];
+    return {
+      // Firefox's getScreenCTM omits ancestor CSS zoom; use the actual viewport rectangle.
+      points: points.map(([x, y, axis]) => ({
+        x: rect.left + ((x - view.x) * rect.width) / view.width,
+        y: rect.top + ((y - view.y) * rect.height) / view.height,
+        axis
+      })),
+      ink: rgb(getComputedStyle(path).color),
+      paper: rgb(getComputedStyle(document.body).backgroundColor)
+    };
+  });
+  const { data, info } = await sharp(await page.screenshot())
+    .removeAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const channel = reference.ink
+    .map((ink, index) => Math.abs(ink - reference.paper[index]))
+    .reduce((best, value, index, differences) => (value > differences[best] ? index : best), 0);
+  for (const point of reference.points) {
+    const coverage = Array.from({ length: 5 }, (_, i) => {
+      const x = Math.floor(point.x) + (point.axis === "vertical" ? i - 2 : 0);
+      const y = Math.floor(point.y) + (point.axis === "horizontal" ? i - 2 : 0);
+      const pixel = data[(y * info.width + x) * info.channels + channel];
+      return (pixel - reference.paper[channel]) / (reference.ink[channel] - reference.paper[channel]);
+    });
+    assert.ok(Math.max(...coverage) > 0.94, `Hairline faded or vanished at ${info.width}px: ${coverage}`);
+  }
+}

--- a/tests/configuration/config.test.ts
+++ b/tests/configuration/config.test.ts
@@ -234,6 +234,58 @@ test("new volumes use this site's name and partial volume metadata inherits a co
   assert.deepEqual(volume.postscript, []);
 });
 
+test("volume decorations inherit Life, accept a fixed theme or opt out, and reject unknown names", () => {
+  assert.equal(resolveVolumeConfig(4, site.name).decoration.kind, "life");
+  assert.equal(resolveVolumeConfig(4, site.name, { decoration: undefined }).decoration.kind, "life");
+  for (const decoration of ["circuit", "archive", "study", "prism", "life", false] as const) {
+    const config = resolveConfig({ site, volumes: { 4: { decoration } } });
+    assert.equal(resolveVolumeConfig(4, site.name, config.volumes[4]).decoration.kind, decoration);
+  }
+  // @ts-expect-error Also reject misspelled names in JavaScript configurations.
+  assert.throws(() => resolveConfig({ site, volumes: { 4: { decoration: "circut" } } }), /volumes.4.decoration/);
+});
+
+test("illustration options preserve defaults and accept static, slower, and calendar overrides", () => {
+  const decoration = { kind: "study", animated: false, speed: 0.5, calendar: { month: 2, day: 29 } } as const;
+  const config = resolveConfig({ site, volumes: { 4: { decoration } } });
+  assert.deepEqual(resolveVolumeConfig(4, site.name, config.volumes[4]).decoration, decoration);
+  assert.deepEqual(
+    resolveVolumeConfig(4, site.name, {
+      decoration: { kind: "prism", animated: undefined, speed: undefined }
+    }).decoration,
+    { kind: "prism", animated: true, speed: 1, calendar: { month: 12, day: 31 } }
+  );
+  for (const speed of [0.25, 4]) {
+    assert.doesNotThrow(() => resolveConfig({ site, volumes: { 4: { decoration: { kind: "circuit", speed } } } }));
+  }
+});
+
+test("invalid illustration options report the editable field", () => {
+  const invalid = (decoration: unknown) =>
+    // @ts-expect-error JavaScript configurations can bypass the public types.
+    resolveConfig({ site, volumes: { 4: { decoration } } });
+  const cases: readonly [unknown, RegExp][] = [
+    [null, /volumes.4.decoration/],
+    [[], /volumes.4.decoration/],
+    [{}, /volumes.4.decoration.kind/],
+    [{ kind: "life" }, /volumes.4.decoration.kind/],
+    [{ kind: "study", animated: "false" }, /volumes.4.decoration.animated/],
+    ...[0, 0.1, 4.1, NaN, Infinity, "slow"].map((speed): [unknown, RegExp] => [
+      { kind: "circuit", speed },
+      /volumes.4.decoration.speed/
+    ]),
+    [{ kind: "prism", calendar: { month: 12, day: 31 } }, /volumes.4.decoration.calendar/],
+    [{ kind: "study", calendar: null }, /volumes.4.decoration.calendar/],
+    [{ kind: "study", calendar: { month: 0, day: 1 } }, /volumes.4.decoration.calendar.month/],
+    [{ kind: "study", calendar: { month: 13, day: 1 } }, /volumes.4.decoration.calendar.month/],
+    [{ kind: "study", calendar: { month: 2, day: 30 } }, /volumes.4.decoration.calendar.day/],
+    [{ kind: "study", calendar: { month: 4, day: 31 } }, /volumes.4.decoration.calendar.day/],
+    [{ kind: "study", calendar: { month: 12, day: 0 } }, /volumes.4.decoration.calendar.day/],
+    [{ kind: "study", calendar: { month: 12, day: 1.5 } }, /volumes.4.decoration.calendar.day/]
+  ];
+  for (const [decoration, field] of cases) assert.throws(() => invalid(decoration), field);
+});
+
 test("undefined volume fields inherit defaults without losing optional metadata or empty lists", () => {
   const overrides = { title: undefined, listLabel: undefined, phileSort: undefined, postscript: undefined };
   assert.deepEqual(resolveVolumeConfig(4, site.name, overrides), resolveVolumeConfig(4, site.name));


### PR DESCRIPTION
## Summary

Volume headers previously shared the same Game of Life frame. Add distinct circuit, archive, study and prism illustrations for volumes 0–3, using the site's font and colors. CPU signals transfer independent random bytes; motion pauses offscreen, in hidden tabs and for reduced motion. Article headers retain Life.

Document and validate per-volume theme selection, hiding artwork, static mode, playback speed and the study calendar date. Keep Life as the default for unconfigured volumes. Resolve volume settings and entry labels once, and share animation timing and activity handling. Preserve thin strokes under mobile zoom and smooth movement for steam and scanning elements.

## Scope

- [x] User-facing behavior
- [ ] Content
- [x] Documentation
- [ ] Tooling or automation
- [ ] Build, CI, or deployment
- [x] Performance or maintenance

## Verification

- `pnpm install --frozen-lockfile`, `pnpm format`, `pnpm lint`, `pnpm test` (85 passed), and `pnpm build` (includes `pnpm check`) in an independent clean checkout.
- Chromium and Firefox: `volume-decorations`, `volume-rendering`, `credits`, and `animations` browser suites. Covers 320–1280px layouts, stroke visibility, continuous steam movement, lifecycle pauses, no-JavaScript artwork and CPU byte boundaries/repeats.
- Production-build configuration fixture in both browsers: static CPU, doubled/halved animation speeds, February 29 calendar, reduced motion and mobile containment.

## Notes

No new runtime dependencies. The four illustrations render without JavaScript; the shared activity observer controls animation, and the circuit reuses CSS animation events instead of a separate timer.
