### PR TITLE
feat(philes): add configurable article algorithm artwork

### DIFF
--- a/README
+++ b/README
@@ -94,6 +94,7 @@ Optional fields:
     slug
     redacted
     lang
+    decoration
 
 Credits come from each file's Git history, including renames and
 Co-authored-by trailers.  The original author appears first, followed by
@@ -114,6 +115,43 @@ supports the custom ink block syntax.
 Ink style reference:
 
     https://www.cubeyond.net/volume/3/ansi-ink-phile/
+
+Article header artwork is chosen from the article's public URL. It stays the
+same across reloads, rebuilds, and adding/removing other articles. Renaming its
+slug or moving it to another volume can choose a different effect. The default
+pool is `life`, `maze` (depth-first maze carving), `sort` (insertion sort),
+`bits` (four byte registers), `asm` (a small assembly loop), and `reorder`
+(out-of-order execution with in-order retirement). No extra controls interrupt
+the reading layout.
+
+Configure the pool and playback in `entropic.config.ts`:
+
+    philes: {
+      decoration: {
+        effects: ["life", "maze", "sort", "bits", "asm", "reorder"],
+        animated: true,
+        speed: 1
+      }
+    }
+
+Omitted options inherit these defaults. `effects` must contain at least one
+unique algorithm; use a single item to show the same effect everywhere.
+Reordering the pool does not reshuffle articles. For the new effects, `speed`
+ranges from 0.25 to 4 and `animated: false` keeps a still frame. The new artwork
+also stays visible without JavaScript. Life uses its original renderer, grid,
+color, and timing; these playback options do not change it. All effects
+pause offscreen, in hidden tabs, and for reduced motion.
+
+Set `decoration: maze` (or any other effect name) in an article's frontmatter
+to pin its effect, including one outside the global pool. `decoration: false`
+removes that article's artwork and closes the unused header space.
+`philes.decoration: false` disables all article artwork, including overrides.
+
+The processor illustrations use native Gohu text at the article's font size.
+`bits` highlights the bits changed by XOR, rotate, and shift operations. `asm`
+shows an executed instruction with its resulting registers and flags. `reorder`
+shows dependency waits and two execution slots; completed instructions remain
+in the queue until all earlier instructions can retire.
 
 Example:
 
@@ -184,7 +222,7 @@ an 8-bit value, including 00 and FF; consecutive random values may repeat.
 
 The new illustrations remain visible without JavaScript. Their motion pauses
 offscreen, in hidden tabs, and when reduced motion is requested. Article
-headers keep their own Game of Life artwork.
+headers use the separate `philes.decoration` settings described above.
 
 
 Redactions

--- a/entropic.config.ts
+++ b/entropic.config.ts
@@ -109,7 +109,14 @@ export default {
     // Inspect selected numbers and bytes. Defaults to true; false disables it.
     inspect: true,
     // Share and open links to selected article text. Defaults to true.
-    fragmentLinks: true
+    fragmentLinks: true,
+    // Each article keeps one algorithm, chosen from its URL. false hides all article artwork.
+    // Frontmatter decoration: maze (or life, sort, bits, asm, reorder, false) pins an article's effect.
+    decoration: {
+      effects: ["life", "maze", "sort", "bits", "asm", "reorder"],
+      animated: true, // New effects only: false keeps a still frame.
+      speed: 1 // New effects only: playback multiplier, 0.25..4. Life keeps its original behavior.
+    }
   },
 
   // 88x31 buttons. Each item has label, imageSrc, and exactly one action:

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -1,10 +1,12 @@
 import { cvePagePath } from "../features/cves/index.ts";
+import { defaultAlgorithmOptions } from "../shared/textmode/algorithm-art/model.ts";
 import { defaultAppearance, defaultEffects, defaultHomeAsciiArt, defaultTextmode } from "./defaults.ts";
 import type { EntropicConfig, HomeSection, ResolvedVolumeConfig, VolumeConfig } from "./types.ts";
-import { validateConfig } from "./validate.ts";
+import { validateArticleDecoration, validateConfig } from "./validate.ts";
 
 /** Resolve nested groups explicitly; undefined inherits and arrays replace whole lists. */
 export function resolveConfig(input: EntropicConfig) {
+  validateArticleDecoration(input.philes?.decoration);
   const appearance = input.theme?.appearance;
   const particles = input.theme?.effects?.particles;
   const glitch = input.theme?.effects?.homeAsciiGlitch;
@@ -20,7 +22,9 @@ export function resolveConfig(input: EntropicConfig) {
     },
     philes: {
       inspect: input.philes?.inspect ?? true,
-      fragmentLinks: input.philes?.fragmentLinks ?? true
+      fragmentLinks: input.philes?.fragmentLinks ?? true,
+      decoration:
+        input.philes?.decoration === false ? false : mergeDefined(defaultAlgorithmOptions, input.philes?.decoration)
     },
     volumes: input.volumes ?? {},
     cves: {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,4 +1,5 @@
 import type { BadgeArtwork, BadgeArtworkPresetId, SiteBadge } from "../features/site-badges/index.ts";
+import type { AlgorithmOptions } from "../shared/textmode/algorithm-art/model.ts";
 import type { CveRecord, HomeSection, ResearchRecognition, VolumeConfig } from "./types/content.ts";
 import type {
   AppearanceConfig,
@@ -110,6 +111,8 @@ export type EntropicConfig = {
     readonly inspect?: boolean;
     /** Create and open links to selected article text. Defaults to true. */
     readonly fragmentLinks?: boolean;
+    /** Stable per-article artwork. Omit for all algorithms; false hides it site-wide. */
+    readonly decoration?: false | Partial<AlgorithmOptions>;
   };
   /** Keys are non-negative volume numbers, not titles or routes. */
   readonly volumes?: Readonly<Record<number, Partial<VolumeConfig>>>;

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -1,4 +1,5 @@
 import { badgeArtworkPresetIds, calculateBadgeLayout, validateArtworkRotation } from "../features/site-badges/index.ts";
+import { algorithmKinds } from "../shared/textmode/algorithm-art/model.ts";
 import { appearanceCssVariables } from "../shared/textmode/core/css-vars.ts";
 import { safeUrl } from "../shared/urls.ts";
 import type { ResolvedConfig } from "./resolve.ts";
@@ -40,8 +41,8 @@ export function validateConfig(config: ResolvedConfig): void {
     integer(socialImage.width, "site.socialImage.width", 1);
     integer(socialImage.height, "site.socialImage.height", 1);
   }
-  for (const [key, value] of Object.entries(config.philes)) {
-    if (typeof value !== "boolean") fail(`philes.${key}`, "Use true or false.");
+  for (const key of ["inspect", "fragmentLinks"] as const) {
+    if (typeof config.philes[key] !== "boolean") fail(`philes.${key}`, "Use true or false.");
   }
   singleLinePrefix(config.home.sectionPrefix, "home.sectionPrefix");
   singleLinePrefix(config.home.itemPrefix, "home.itemPrefix");
@@ -145,6 +146,30 @@ export function validateConfig(config: ResolvedConfig): void {
     if (/^(?:[a-z]:|\/|\\)/i.test(config.wkd.publicKeyPath) || config.wkd.publicKeyPath.split(/[\\/]/).includes("..")) {
       fail("wkd.publicKeyPath", "Use a repository-relative public key path.");
     }
+  }
+}
+
+export function validateArticleDecoration(value: unknown): void {
+  if (value === undefined || value === false) return;
+  const field = "philes.decoration";
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(field, "Use false or an options object.");
+  if ("effects" in value && value.effects !== undefined) {
+    const effects = value.effects;
+    if (
+      !Array.isArray(effects) ||
+      !effects.length ||
+      new Set(effects).size !== effects.length ||
+      effects.some((kind) => !algorithmKinds.some((known) => known === kind))
+    ) {
+      fail(`${field}.effects`, `Use a non-empty list of unique algorithms: ${algorithmKinds.join(", ")}.`);
+    }
+  }
+  if ("animated" in value && value.animated !== undefined && typeof value.animated !== "boolean") {
+    fail(`${field}.animated`, "Use true or false.");
+  }
+  if ("speed" in value && value.speed !== undefined) {
+    if (typeof value.speed !== "number") fail(`${field}.speed`, "Use a number between 0.25 and 4.");
+    bounded(value.speed, `${field}.speed`, 0.25, 4);
   }
 }
 

--- a/src/features/philes/client.ts
+++ b/src/features/philes/client.ts
@@ -1,8 +1,10 @@
+import { installAlgorithmArt } from "@/shared/textmode/algorithm-art/client";
 import { initLifeArt } from "@/shared/textmode/life/client";
 import { installSelectionTools } from "./selection/client";
 
 export function installPhileInteractions(): void {
   initLifeArt();
+  installAlgorithmArt();
   installSelectionTools();
   if (document.querySelector("[data-lightbox-image]")) {
     void import("@/shared/textmode/lightbox").then(({ installImageLightbox }) => installImageLightbox());

--- a/src/features/philes/components/PhileDecoration.astro
+++ b/src/features/philes/components/PhileDecoration.astro
@@ -1,0 +1,139 @@
+---
+import { createAlgorithm } from "@/shared/textmode/algorithm-art/engine";
+import type { AlgorithmKind, AlgorithmOptions } from "@/shared/textmode/algorithm-art/model";
+import { lifeFrameHtml } from "@/shared/textmode/life";
+import "@/shared/textmode/styles/life.css";
+
+type Props = { kind: AlgorithmKind; articleKey: string; options: AlgorithmOptions };
+const { kind, articleKey, options } = Astro.props;
+const frame = kind === "life" ? undefined : createAlgorithm(kind, articleKey).next();
+---
+
+{
+  kind === "life" ? (
+    <pre
+      class="textmode-pre phile-pre phile-header-side life-art"
+      data-life-root
+      data-algorithm-art="life"
+      aria-hidden="true"
+      set:html={lifeFrameHtml()}
+    />
+  ) : (
+    frame && (
+      <div
+        class="phile-header-side phile-decoration"
+        data-algorithm-art={kind}
+        data-key={articleKey}
+        data-animated={options.animated || undefined}
+        data-speed={options.speed}
+        aria-hidden="true"
+      >
+        <pre class="textmode-pre phile-pre" set:html={lifeFrameHtml()} />
+        {frame.labels ? (
+          <div class="algorithm-labels" data-algorithm-labels>
+            {frame.labels.map((label) => (
+              <span
+                class={`algorithm-label algorithm-label-${label.tone}`}
+                style={`left:${label.column}ch;top:${label.row}lh`}
+              >
+                {label.text}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <svg viewBox="0 0 184 210" preserveAspectRatio="none" focusable="false">
+            <g data-algorithm-field>
+              <path class="algorithm-ink" data-algorithm-ink d={frame.ink} />
+              <path class="algorithm-trail" data-algorithm-trail d={frame.trail} />
+              <path class="algorithm-accent" data-algorithm-accent d={frame.accent} />
+            </g>
+            <g data-algorithm-motion>
+              {frame.motion?.map((shape) => (
+                <rect
+                  class={shape.accent ? "algorithm-accent" : "algorithm-ink"}
+                  x={shape.fromX}
+                  y={shape.fromY}
+                  width={shape.width}
+                  height={shape.height}
+                />
+              ))}
+            </g>
+          </svg>
+        )}
+      </div>
+    )
+  )
+}
+
+<style>
+  .phile-decoration {
+    /* Match the bitmap font's rounded advance under mobile CSS zoom. */
+    left: auto;
+    right: 0;
+    width: 25ch;
+    height: 17lh;
+    font-family: var(--text-font);
+    font-size: var(--text-size);
+    line-height: 1;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  .phile-decoration pre {
+    position: relative;
+    z-index: 1;
+  }
+
+  svg {
+    position: absolute;
+    /* Gohu's box strokes run through the middle of the outer character cells. */
+    top: 0.5lh;
+    left: 0.5ch;
+    width: 24ch;
+    height: 16lh;
+    overflow: hidden;
+    shape-rendering: crispEdges;
+  }
+
+  .phile-decoration :global(.algorithm-ink) {
+    fill: var(--fg);
+    opacity: 0.45;
+  }
+
+  .phile-decoration[data-algorithm-art="sort"] :global(.algorithm-ink) {
+    opacity: 0.55;
+  }
+
+  .algorithm-trail {
+    fill: var(--link);
+    opacity: 0.4;
+  }
+
+  .phile-decoration :global(.algorithm-accent) {
+    fill: var(--link);
+  }
+
+  .algorithm-labels {
+    position: absolute;
+    top: 1lh;
+    left: 1ch;
+    width: 23ch;
+    height: 15lh;
+    white-space: pre;
+  }
+
+  .algorithm-labels :global(.algorithm-label) {
+    position: absolute;
+    color: var(--fg);
+    opacity: 0.7;
+  }
+
+  .algorithm-labels :global(.algorithm-label-muted) {
+    opacity: 0.3;
+  }
+
+  .algorithm-labels :global(.algorithm-label-accent) {
+    color: var(--link);
+    opacity: 1;
+  }
+</style>

--- a/src/features/philes/components/PhileShell.astro
+++ b/src/features/philes/components/PhileShell.astro
@@ -2,8 +2,8 @@
 import { phileConfig } from "@/config/server";
 import type { Phile } from "../model";
 import { renderPhile } from "../rendering";
+import PhileDecoration from "./PhileDecoration.astro";
 import SelectionTools from "./SelectionTools.astro";
-import "@/shared/textmode/styles/life.css";
 import "@/shared/textmode/styles/ansi.css";
 import "../styles.css";
 
@@ -16,7 +16,15 @@ const { header, body, footerHtml } = renderPhile(Astro.props.phile);
     class="phile-header relative z-2"
     style={`--phile-header-lines: ${header.lineCount}; --phile-meta-lines: ${header.metaLineCount}; --phile-title-lines: ${header.titleLineCount}`}
   >
-    <pre class="textmode-pre phile-pre phile-header-side life-art" data-life-root set:html={header.sideHtml} />
+    {
+      header.decoration && phileConfig.decoration && (
+        <PhileDecoration
+          kind={header.decoration}
+          articleKey={Astro.props.phile.route.href}
+          options={phileConfig.decoration}
+        />
+      )
+    }
     <pre class="textmode-pre phile-pre phile-header-meta" set:html={header.metaHtml} />
   </header>
   {

--- a/src/features/philes/content/schema.ts
+++ b/src/features/philes/content/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "astro/zod";
+import { algorithmKinds } from "@/shared/textmode/algorithm-art/model";
 
 export const requiredPhileFields = ["title", "date"] as const;
 
@@ -8,5 +9,6 @@ export const phileSchema = z.object({
   lang: z.enum(["en", "zh"]).default("en"),
   slug: z.string().optional(),
   order: z.number().int().nonnegative().optional(),
-  redacted: z.boolean().default(false)
+  redacted: z.boolean().default(false),
+  decoration: z.union([z.enum(algorithmKinds), z.literal(false)]).optional()
 });

--- a/src/features/philes/rendering/render.ts
+++ b/src/features/philes/rendering/render.ts
@@ -1,8 +1,9 @@
 import { decodeHTMLAttribute } from "entities/decode";
-import { textmodeConfig } from "@/config/server";
+import { phileConfig, textmodeConfig } from "@/config/server";
 import { escapeHtml, link, textHtml, trimBlankLines, wrapWordsCells } from "@/shared/textmode";
+import { type AlgorithmKind, selectAlgorithm } from "@/shared/textmode/algorithm-art/model";
 import { renderAnsiText } from "@/shared/textmode/ansi";
-import { lifeFrameHeight, lifeFrameHtml } from "@/shared/textmode/life";
+import { lifeFrameHeight } from "@/shared/textmode/life";
 import { safeUrl } from "@/shared/urls";
 import type { Phile } from "../model";
 import { renderRedactedBody } from "./redacted";
@@ -11,7 +12,7 @@ const titleWidth = textmodeConfig.articleArtIndent - textmodeConfig.textIndent;
 
 export type PhileHeader = {
   metaHtml: string;
-  sideHtml: string;
+  decoration: AlgorithmKind | false;
   lineCount: number;
   metaLineCount: number;
   titleLineCount: number;
@@ -44,11 +45,15 @@ function renderPhileHeader(phile: Phile): PhileHeader {
   const titleLines = wrapWordsCells(phile.data.title, titleWidth);
   const author = phile.credits[0];
   const metaLines = [...titleLines, ...(author ? wrapWordsCells(`~ ${author.name}`, titleWidth) : [])];
+  const decoration =
+    phileConfig.decoration === false
+      ? false
+      : (phile.data.decoration ?? selectAlgorithm(phile.route.href, phileConfig.decoration.effects));
 
   return {
     metaHtml: metaLines.map(textHtml).join("\n"),
-    sideHtml: lifeFrameHtml(),
-    lineCount: lifeFrameHeight,
+    decoration,
+    lineCount: decoration ? lifeFrameHeight : 0,
     metaLineCount: metaLines.length,
     titleLineCount: titleLines.length
   };

--- a/src/features/philes/styles.css
+++ b/src/features/philes/styles.css
@@ -9,7 +9,7 @@
 
   .phile-header {
     width: calc(var(--text-cell) * 85);
-    height: calc(var(--text-size) * max(18, 17 + var(--phile-meta-lines)));
+    height: calc(var(--text-size) * (max(0, var(--phile-header-lines) - 1) + var(--phile-meta-lines) + 1));
   }
 
   .phile-header-side {
@@ -20,7 +20,7 @@
 
   .phile-header-meta {
     position: absolute;
-    top: calc(var(--text-size) * 16);
+    top: calc(var(--text-size) * max(0, var(--phile-header-lines) - 1));
     left: 0;
     padding-left: calc(var(--text-cell) * 4);
   }

--- a/src/shared/textmode/algorithm-art/client.ts
+++ b/src/shared/textmode/algorithm-art/client.ts
@@ -1,0 +1,160 @@
+import { observeAnimationActivity } from "@/shared/browser/animation-activity";
+import { createAlgorithm, renderBars } from "./engine";
+import type { AlgorithmFrame } from "./frame";
+import { algorithmKinds } from "./model";
+
+let installed = false;
+
+export function installAlgorithmArt(): void {
+  if (installed) return;
+  installed = true;
+  for (const root of document.querySelectorAll<HTMLElement>("[data-algorithm-art]")) {
+    const kind = algorithmKinds.find((value) => value === root.dataset.algorithmArt);
+    if (!kind || kind === "life") continue;
+    const algorithm = createAlgorithm(kind, root.dataset.key ?? "");
+    const speed = Number(root.dataset.speed) || 1;
+    let current = algorithm.next(); // Same initial frame as the server-rendered HTML.
+    const labels = root.querySelector("[data-algorithm-labels]");
+    if (labels) {
+      const draw = labelRenderer(labels);
+      draw(current);
+      animateSteps(root, algorithm.intervalMs / speed, () => draw(algorithm.next()));
+      continue;
+    }
+    const svg = root.querySelector("svg");
+    const field = root.querySelector("[data-algorithm-field]");
+    const ink = root.querySelector("[data-algorithm-ink]");
+    const trail = root.querySelector("[data-algorithm-trail]");
+    const accent = root.querySelector("[data-algorithm-accent]");
+    const motion = root.querySelector("[data-algorithm-motion]");
+    if (!svg || !field || !ink || !trail || !accent || !motion) continue;
+    const blocks = [...motion.querySelectorAll("rect")];
+    let requestId = 0;
+    let previousTime: number | undefined;
+    let elapsed = 0;
+    let scaleX = 1;
+    let scaleY = 1;
+    let pixelWidth = 184;
+    let pixelHeight = 210;
+    let originX = 0;
+    let originY = 0;
+    const fit = () => {
+      const bounds = svg.getBoundingClientRect();
+      if (bounds.width <= 0 || bounds.height <= 0) return;
+      pixelWidth = bounds.width * window.devicePixelRatio;
+      pixelHeight = bounds.height * window.devicePixelRatio;
+      originX = bounds.left * window.devicePixelRatio;
+      originY = bounds.top * window.devicePixelRatio;
+      scaleX = pixelWidth / svg.viewBox.baseVal.width || 1;
+      scaleY = pixelHeight / svg.viewBox.baseVal.height || 1;
+      drawStep();
+      drawPosition();
+    };
+    const snap = (value: number, scale: number) => (Math.round(value * scale) / scale).toFixed(3);
+    const drawStep = () => {
+      const paths = current.bars
+        ? renderBars(
+            current.bars.values,
+            current.bars.active,
+            Math.round(originX + pixelWidth) - Math.round(originX),
+            Math.round(originY + pixelHeight) - Math.round(originY),
+            Math.max(1, Math.round(2 * scaleX))
+          )
+        : current;
+      if (current.bars) {
+        set(
+          field,
+          "transform",
+          `matrix(${1 / scaleX} 0 0 ${1 / scaleY} ${(Math.round(originX) - originX) / scaleX} ${(Math.round(originY) - originY) / scaleY})`
+        );
+      }
+      set(ink, "d", paths.ink);
+      set(trail, "d", current.trail ?? "");
+      set(accent, "d", paths.accent);
+      while (blocks.length < (current.motion?.length ?? 0)) {
+        const block = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+        blocks.push(block);
+        motion.append(block);
+      }
+      blocks.forEach((block, index) => {
+        const shape = current.motion?.[index];
+        set(block, "width", shape?.width ?? 0);
+        set(block, "height", shape?.height ?? 0);
+        set(block, "class", shape?.accent ? "algorithm-accent" : "algorithm-ink");
+      });
+    };
+    const drawPosition = () => {
+      const progress = elapsed / algorithm.intervalMs;
+      const ease = progress * progress * (3 - 2 * progress);
+      current.motion?.forEach((shape, index) => {
+        const block = blocks[index];
+        if (!block) return;
+        set(block, "x", snap(shape.fromX + (shape.x - shape.fromX) * ease, scaleX));
+        set(block, "y", snap(shape.fromY + (shape.y - shape.fromY) * ease, scaleY));
+      });
+    };
+    const tick = (time: number) => {
+      if (previousTime !== undefined) elapsed += Math.min(time - previousTime, 64) * speed;
+      previousTime = time;
+      while (elapsed >= algorithm.intervalMs) {
+        elapsed -= algorithm.intervalMs;
+        current = algorithm.next();
+        drawStep();
+      }
+      drawPosition();
+      requestId = requestAnimationFrame(tick);
+    };
+    new ResizeObserver(fit).observe(svg);
+    window.addEventListener("resize", fit, { passive: true });
+    fit();
+    if (!current.motion) {
+      animateSteps(root, algorithm.intervalMs / speed, () => {
+        current = algorithm.next();
+        drawStep();
+      });
+      continue;
+    }
+    if (!root.hasAttribute("data-animated")) continue;
+    observeAnimationActivity((active) => {
+      cancelAnimationFrame(requestId);
+      previousTime = undefined;
+      if (!active) return;
+      fit();
+      requestId = requestAnimationFrame(tick);
+    }, root);
+  }
+}
+
+/** Discrete effects sleep between steps; only the maze needs intermediate cursor positions. */
+function animateSteps(root: HTMLElement, intervalMs: number, draw: () => void): void {
+  if (!root.hasAttribute("data-animated")) return;
+  let timer: number | undefined;
+  observeAnimationActivity((active) => {
+    window.clearInterval(timer);
+    if (active) timer = window.setInterval(draw, intervalMs);
+  }, root);
+}
+
+function labelRenderer(root: Element): (frame: AlgorithmFrame) => void {
+  const nodes = [...root.querySelectorAll("span")];
+  return (frame) => {
+    const labels = frame.labels ?? [];
+    while (nodes.length > labels.length) nodes.pop()?.remove();
+    labels.forEach((label, index) => {
+      let node = nodes[index];
+      if (!node) {
+        node = document.createElement("span");
+        nodes.push(node);
+        root.append(node);
+      }
+      set(node, "class", `algorithm-label algorithm-label-${label.tone}`);
+      set(node, "style", `left:${label.column}ch;top:${label.row}lh`);
+      if (node.textContent !== label.text) node.textContent = label.text;
+    });
+  };
+}
+
+function set(element: Element, name: string, value: string | number): void {
+  const text = String(value);
+  if (element.getAttribute(name) !== text) element.setAttribute(name, text);
+}

--- a/src/shared/textmode/algorithm-art/engine.ts
+++ b/src/shared/textmode/algorithm-art/engine.ts
@@ -1,0 +1,193 @@
+import type { Algorithm, MovingRect, Random } from "./frame";
+import { type AlgorithmKind, hashSeed } from "./model";
+import { assembly, bits, reorder } from "./processors";
+
+export type { AlgorithmFrame } from "./frame";
+
+/** SVG geometry and native character labels, shared by static HTML and browser playback. */
+export function createAlgorithm(kind: Exclude<AlgorithmKind, "life">, key: string): Algorithm {
+  let state = hashSeed(`${key}\0${kind}`);
+  const random = () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+  switch (kind) {
+    case "maze":
+      return maze(random);
+    case "sort":
+      return sort(random);
+    case "bits":
+      return bits(random);
+    case "asm":
+      return assembly(random);
+    case "reorder":
+      return reorder(random);
+  }
+}
+
+function rect(x: number, y: number, width: number, height = width): string {
+  return `M${x} ${y}h${width}v${height}h-${width}z`;
+}
+
+/** Distribute leftover pixels among bar widths, keeping every gap exactly the same. */
+export function renderBars(values: readonly number[], active: number, width = 184, height = 210, gap = 2) {
+  const available = width - gap * (values.length - 1);
+  let ink = "";
+  let accent = "";
+  for (const [index, value] of values.entries()) {
+    const left = Math.round((index * available) / values.length) + index * gap;
+    const right = Math.round(((index + 1) * available) / values.length) + index * gap;
+    const barHeight = Math.round((value * height) / values.length);
+    const bar = rect(left, height - barHeight, right - left, barHeight);
+    if (index === active) accent += bar;
+    else ink += bar;
+  }
+  return { ink, accent };
+}
+
+function maze(random: Random): Algorithm {
+  const columns = 13;
+  const rows = 15;
+  const visited = new Uint8Array(columns * rows);
+  // Each cell owns its east and south walls. Carving removes the shared wall.
+  const walls = new Uint8Array(visited.length);
+  let stack: number[] = [];
+  let hold = 0;
+  let renewRow = -1;
+  let history: number[] = [];
+  const x = (column: number) => Math.round((column * 184) / columns);
+  const y = (row: number) => row * 14;
+  const start = () => {
+    visited.fill(0);
+    const cell = Math.floor(random() * visited.length);
+    visited[cell] = 1;
+    stack = [cell];
+    history = [cell];
+  };
+  const carve = () => {
+    const cell = stack.at(-1);
+    if (cell === undefined) return;
+    const column = cell % columns;
+    const neighbors = [
+      ...(column > 0 ? [cell - 1] : []),
+      ...(column < columns - 1 ? [cell + 1] : []),
+      ...(cell >= columns ? [cell - columns] : []),
+      ...(cell < columns * (rows - 1) ? [cell + columns] : [])
+    ].filter((neighbor) => !visited[neighbor]);
+    if (neighbors.length) {
+      const next = neighbors[Math.floor(random() * neighbors.length)] ?? cell;
+      const owner = Math.min(cell, next);
+      walls[owner] = (walls[owner] ?? 0) & ~(Math.abs(next - cell) === 1 ? 1 : 2);
+      visited[next] = 1;
+      stack.push(next);
+    } else {
+      // Backtrack one passage at a time; never teleport across the maze.
+      stack.pop();
+    }
+    const next = stack.at(-1);
+    if (next !== undefined) history = [...history.slice(-3), next];
+  };
+  walls.fill(3);
+  start();
+  for (let step = 0; step < 60; step += 1) carve();
+  return {
+    intervalMs: 120,
+    next() {
+      const previous = stack.at(-1);
+      if (hold > 0) {
+        hold -= 1;
+        if (!hold) renewRow = 0;
+      } else if (renewRow >= 0) {
+        // Rebuild a row at a time instead of flashing a fresh grid across the whole frame.
+        walls.fill(3, renewRow * columns, (renewRow + 1) * columns);
+        renewRow += 1;
+        if (renewRow === rows) {
+          renewRow = -1;
+          start();
+        }
+      } else {
+        carve();
+        if (!stack.length) {
+          hold = 18;
+          history = [];
+        }
+      }
+      let ink = "";
+      for (const [cell, wall] of walls.entries()) {
+        const column = cell % columns;
+        const row = Math.floor(cell / columns);
+        if (wall & 1 && column < columns - 1) ink += rect(x(column + 1) - 1, y(row), 2, 14);
+        if (wall & 2 && row < rows - 1) ink += rect(x(column), y(row + 1) - 1, x(column + 1) - x(column), 2);
+      }
+      const cursor = stack.at(-1);
+      const motion: MovingRect[] = [];
+      let trail = "";
+      if (cursor !== undefined) {
+        const from = previous ?? cursor;
+        motion.push({
+          fromX: x(from % columns) + 5,
+          fromY: y(Math.floor(from / columns)) + 5,
+          x: x(cursor % columns) + 5,
+          y: y(Math.floor(cursor / columns)) + 5,
+          width: 4,
+          height: 4,
+          accent: true
+        });
+        // Only the recent footsteps are visible, keeping the maze itself readable.
+        for (let index = 1; index < history.length; index += 1) {
+          const a = history[index - 1] ?? cursor;
+          const b = history[index] ?? cursor;
+          const ax = x(a % columns) + 6;
+          const ay = y(Math.floor(a / columns)) + 6;
+          const bx = x(b % columns) + 6;
+          const by = y(Math.floor(b / columns)) + 6;
+          trail += rect(Math.min(ax, bx), Math.min(ay, by), Math.abs(bx - ax) + 2, Math.abs(by - ay) + 2);
+        }
+      }
+      return {
+        ink,
+        accent: "",
+        trail,
+        motion
+      };
+    }
+  };
+}
+
+function sort(random: Random): Algorithm {
+  const bars = Array.from({ length: 14 }, (_, index) => index + 1);
+  let sorted = 1;
+  let cursor = 1;
+  let hold = 0;
+  const shuffle = () => {
+    for (let index = bars.length - 1; index > 0; index -= 1) {
+      const other = Math.floor(random() * (index + 1));
+      const value = bars[index] ?? 1;
+      bars[index] = bars[other] ?? 1;
+      bars[other] = value;
+    }
+    sorted = 1;
+    cursor = 1;
+  };
+  shuffle();
+  return {
+    intervalMs: 180,
+    next() {
+      if (hold > 0) {
+        hold -= 1;
+        if (!hold) shuffle();
+      } else if (cursor > 0 && (bars[cursor - 1] ?? 0) > (bars[cursor] ?? 0)) {
+        const value = bars[cursor] ?? 1;
+        bars[cursor] = bars[cursor - 1] ?? 1;
+        bars[cursor - 1] = value;
+        cursor -= 1;
+      } else {
+        sorted += 1;
+        cursor = sorted;
+        if (sorted === bars.length) hold = 14;
+      }
+      const active = hold ? -1 : cursor;
+      return { ...renderBars(bars, active), bars: { values: [...bars], active } };
+    }
+  };
+}

--- a/src/shared/textmode/algorithm-art/frame.ts
+++ b/src/shared/textmode/algorithm-art/frame.ts
@@ -1,0 +1,28 @@
+export type MovingRect = {
+  fromX: number;
+  fromY: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  accent: boolean;
+};
+
+/** Native Gohu text, positioned in the frame's 23 x 15 inner character cells. */
+export type ArtLabel = {
+  column: number;
+  row: number;
+  text: string;
+  tone: "ink" | "muted" | "accent";
+};
+
+export type AlgorithmFrame = {
+  ink: string;
+  accent: string;
+  trail?: string;
+  motion?: readonly MovingRect[];
+  bars?: { values: readonly number[]; active: number };
+  labels?: readonly ArtLabel[];
+};
+export type Algorithm = { intervalMs: number; next: () => AlgorithmFrame };
+export type Random = () => number;

--- a/src/shared/textmode/algorithm-art/model.ts
+++ b/src/shared/textmode/algorithm-art/model.ts
@@ -1,0 +1,41 @@
+export const algorithmKinds = ["life", "maze", "sort", "bits", "asm", "reorder"] as const;
+export type AlgorithmKind = (typeof algorithmKinds)[number];
+
+export type AlgorithmOptions = {
+  readonly effects: readonly AlgorithmKind[];
+  /** Pause the new effects. Life keeps its original playback behavior. */
+  readonly animated: boolean;
+  /** Playback multiplier for the new effects, 0.25..4. Life keeps its original timing. */
+  readonly speed: number;
+};
+
+export const defaultAlgorithmOptions: AlgorithmOptions = {
+  effects: algorithmKinds,
+  animated: true,
+  speed: 1
+};
+
+/** Rank each candidate separately: reordering the pool never changes an article's artwork. */
+export function selectAlgorithm(key: string, effects: readonly AlgorithmKind[]): AlgorithmKind {
+  let selected = effects[0];
+  if (!selected) throw new RangeError("Article artwork needs at least one algorithm.");
+  let highest = -1;
+  for (const kind of effects) {
+    const score = hashSeed(`${key}\0${kind}`);
+    if (score > highest || (score === highest && kind < selected)) {
+      selected = kind;
+      highest = score;
+    }
+  }
+  return selected;
+}
+
+export function hashSeed(key: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < key.length; index += 1) {
+    hash = Math.imul(hash ^ key.charCodeAt(index), 16777619);
+  }
+  hash = Math.imul(hash ^ (hash >>> 16), 0x85ebca6b);
+  hash = Math.imul(hash ^ (hash >>> 13), 0xc2b2ae35);
+  return (hash ^ (hash >>> 16)) >>> 0;
+}

--- a/src/shared/textmode/algorithm-art/processors.ts
+++ b/src/shared/textmode/algorithm-art/processors.ts
@@ -1,0 +1,299 @@
+import type { Algorithm, AlgorithmFrame, ArtLabel, Random } from "./frame";
+
+const hex = (value: number, width = 2) => value.toString(16).toUpperCase().padStart(width, "0");
+const byte = (random: Random) => Math.floor(random() * 256);
+const label = (column: number, row: number, text: string, tone: ArtLabel["tone"] = "ink"): ArtLabel => ({
+  column,
+  row,
+  text,
+  tone
+});
+const rule = (row: number) => label(0, row, "─".repeat(23), "muted");
+const frame = (labels: ArtLabel[]): AlgorithmFrame => ({ ink: "", accent: "", labels });
+
+const bitOperations = ["XOR", "ROL", "SHR"] as const;
+type BitOperation = (typeof bitOperations)[number];
+
+export function applyBitOperation(value: number, operation: BitOperation, operand: number): number {
+  switch (operation) {
+    case "XOR":
+      return (value ^ operand) & 255;
+    case "ROL": {
+      const count = operand & 7;
+      return ((value << count) | (value >>> (8 - count))) & 255;
+    }
+    case "SHR":
+      return value >>> operand;
+  }
+}
+
+export function bits(random: Random): Algorithm {
+  const registers = Array.from({ length: 4 }, () => byte(random));
+  const operations = registers.map(() => "INIT");
+  const columns = Array.from({ length: 8 }, (_, index) => ({ column: index * 3, mask: 128 >>> index, bit: 7 - index }));
+  let tick = 0;
+  return {
+    intervalMs: 480,
+    next() {
+      tick = (tick + 1) & 65535;
+      const active = Math.floor(random() * registers.length);
+      const operation = bitOperations[Math.floor(random() * bitOperations.length)] ?? "XOR";
+      const operand = operation === "XOR" ? 1 + Math.floor(random() * 255) : 1 + Math.floor(random() * 3);
+      const previous = registers[active] ?? 0;
+      registers[active] = applyBitOperation(previous, operation, operand);
+      operations[active] = `${operation} ${hex(operand)}`;
+      const labels = [label(0, 0, "BIT / 08"), label(17, 0, `T ${hex(tick, 4)}`, "muted"), rule(1)];
+      for (const [index, value] of registers.entries()) {
+        const row = 2 + index * 3;
+        labels.push(
+          label(0, row, `R${index}`, index === active ? "accent" : "ink"),
+          label(3, row, operations[index] ?? "", index === active ? "accent" : "muted"),
+          label(19, row, `0x${hex(value)}`)
+        );
+        for (const { column, mask } of columns) {
+          const changed = index === active && (previous ^ value) & mask;
+          const on = value & mask;
+          for (const y of [row + 1, row + 2]) {
+            labels.push(label(column, y, on ? "██" : "░░", changed ? "accent" : on ? "ink" : "muted"));
+          }
+        }
+      }
+      // Each digit shares its bit block's column, centered in the two-character cell.
+      for (const { column, bit } of columns) labels.push(label(column + 0.5, 14, String(bit), "muted"));
+      return frame(labels);
+    }
+  };
+}
+
+/** A small byte machine: its highlighted instruction and visible registers describe the same step. */
+export function createByteMachine(random: Random) {
+  const registers = [0, 0, 0, 0];
+  let pc = 0;
+  let zero = false;
+  let carry = false;
+  let seed = 0;
+  let mask = 0;
+  let count = 0;
+  return {
+    next() {
+      const executed = pc;
+      let changed = -1;
+      if (pc === 0) {
+        seed = byte(random);
+        mask = 1 + Math.floor(random() * 255);
+        count = 3 + Math.floor(random() * 5);
+      }
+      const a = registers[0] ?? 0;
+      const c = registers[2] ?? 0;
+      switch (pc) {
+        case 0:
+          registers[0] = seed;
+          changed = 0;
+          break;
+        case 1:
+          registers[1] = count;
+          changed = 1;
+          break;
+        case 2:
+          registers[0] = a ^ mask;
+          zero = registers[0] === 0;
+          carry = false;
+          changed = 0;
+          break;
+        case 3:
+          registers[0] = applyBitOperation(a, "ROL", 1);
+          carry = Boolean(a & 128);
+          changed = 0;
+          break;
+        case 4:
+          registers[2] = (c + a) & 255;
+          carry = c + a > 255;
+          zero = registers[2] === 0;
+          changed = 2;
+          break;
+        case 5:
+          registers[1] = ((registers[1] ?? 0) - 1) & 255;
+          zero = registers[1] === 0;
+          changed = 1;
+          break;
+        case 7:
+          registers[3] = c;
+          changed = 3;
+          break;
+      }
+      pc = pc === 8 ? 0 : pc === 6 && !zero ? 2 : pc + 1;
+      return {
+        executed,
+        nextPc: pc,
+        registers: [...registers],
+        changed,
+        zero,
+        carry,
+        instructions: [
+          `mov r0, 0x${hex(seed)}`,
+          `mov r1, 0x${hex(count)}`,
+          `xor r0, 0x${hex(mask)}`,
+          "rol r0, 1",
+          "add r2, r0",
+          "dec r1",
+          "jnz 0x02",
+          "mov r3, r2",
+          "jmp 0x00"
+        ]
+      };
+    }
+  };
+}
+
+export function assembly(random: Random): Algorithm {
+  const machine = createByteMachine(random);
+  return {
+    intervalMs: 520,
+    next() {
+      const state = machine.next();
+      const labels = [label(0, 0, "ASM / 08"), label(18, 0, `PC ${hex(state.executed)}`, "accent"), rule(1)];
+      for (const [index, instruction] of state.instructions.entries()) {
+        const active = index === state.executed;
+        labels.push(
+          label(0, index + 2, active ? ">" : "", "accent"),
+          label(2, index + 2, hex(index), "muted"),
+          label(6, index + 2, instruction, active ? "accent" : "ink")
+        );
+      }
+      labels.push(rule(11));
+      for (const [index, value] of state.registers.entries()) {
+        labels.push(
+          label(
+            (index % 2) * 12,
+            12 + Math.floor(index / 2),
+            `R${index} ${hex(value)}`,
+            index === state.changed ? "accent" : "ink"
+          )
+        );
+      }
+      labels.push(
+        label(0, 14, `Z${Number(state.zero)} C${Number(state.carry)}`, "muted"),
+        label(15, 14, (state.registers[0] ?? 0).toString(2).padStart(8, "0"), "muted")
+      );
+      return frame(labels);
+    }
+  };
+}
+
+type QueueStatus = "queued" | "waiting" | "running" | "ready" | "retired";
+type QueueEntry = {
+  op: string;
+  dependencies: number[];
+  latency: number;
+  remaining: number;
+  status: QueueStatus;
+};
+
+/** Two execution slots share a six-entry reorder buffer; retirement always follows program order. */
+export function createReorderQueue(random: Random) {
+  let entries: QueueEntry[] = [];
+  let tick = 0;
+  let issued = 0;
+  let retired = 0;
+  let hold = 0;
+  const reset = () => {
+    const program: [string, number[]][] = [
+      ["LD", []],
+      ["XOR", []],
+      ["ADD", [1]],
+      ["ROL", []],
+      ["XOR", [0]],
+      ["ST", [2, 4]]
+    ];
+    entries = program.map(([op, dependencies], index) => {
+      const latency = index === 0 ? 9 + Math.floor(random() * 4) : 2 + Math.floor(random() * 3);
+      return { op, dependencies, latency, remaining: latency, status: "queued" };
+    });
+    tick = 0;
+    issued = 0;
+    retired = 0;
+  };
+  reset();
+  return {
+    next() {
+      if (hold > 0) {
+        hold -= 1;
+        if (!hold) reset();
+      } else {
+        tick += 1;
+        const head = entries[retired];
+        if (head?.status === "ready") {
+          head.status = "retired";
+          retired += 1;
+        }
+        for (const entry of entries) {
+          if (entry.status !== "running") continue;
+          entry.remaining -= 1;
+          if (!entry.remaining) entry.status = "ready";
+        }
+        const next = entries[issued];
+        if (next) {
+          next.status = "waiting";
+          issued += 1;
+        }
+        let slots = 2 - entries.filter((entry) => entry.status === "running").length;
+        for (const entry of entries) {
+          if (!slots) break;
+          if (
+            entry.status === "waiting" &&
+            entry.dependencies.every((index) => ["ready", "retired"].includes(entries[index]?.status ?? ""))
+          ) {
+            entry.status = "running";
+            slots -= 1;
+          }
+        }
+        if (retired === entries.length) hold = 5;
+      }
+      return { tick, retired, entries: entries.map((entry) => ({ ...entry, dependencies: [...entry.dependencies] })) };
+    }
+  };
+}
+
+export function reorder(random: Random): Algorithm {
+  const queue = createReorderQueue(random);
+  // The static frame already shows work in flight and an out-of-order completion.
+  for (let step = 0; step < 6; step += 1) queue.next();
+  const statuses: Record<QueueStatus, string> = {
+    queued: "--",
+    waiting: "WAIT",
+    running: "RUN",
+    ready: "RDY",
+    retired: "RET"
+  };
+  return {
+    intervalMs: 320,
+    next() {
+      const state = queue.next();
+      const labels = [label(0, 0, "ROB / 06"), label(17, 0, `T ${hex(state.tick, 4)}`, "muted"), rule(1)];
+      for (const [index, entry] of state.entries.entries()) {
+        const row = 2 + index * 2;
+        const running = entry.status === "running";
+        const progress = Math.round((23 * (entry.latency - entry.remaining)) / entry.latency);
+        labels.push(
+          label(0, row, `${hex(index)} ${entry.op}`, entry.status === "retired" ? "muted" : "ink"),
+          label(
+            8,
+            row,
+            entry.dependencies.length ? `<${entry.dependencies.map((id) => hex(id)).join(",")}` : "",
+            "muted"
+          ),
+          label(19, row, statuses[entry.status], running || entry.status === "ready" ? "accent" : "muted"),
+          rule(row + 1),
+          label(0, row + 1, "━".repeat(progress), entry.status === "retired" ? "muted" : "ink"),
+          label(Math.min(progress, 22), row + 1, running ? "▪" : "", "accent")
+        );
+      }
+      labels.push(
+        label(0, 14, "RET", "muted"),
+        label(4, 14, "■".repeat(state.retired) + "·".repeat(6 - state.retired), "accent"),
+        label(16, 14, state.retired === 6 ? "DRAINED" : `NEXT ${hex(state.retired)}`, "muted")
+      );
+      return frame(labels);
+    }
+  };
+}

--- a/tests/browser/animations.mjs
+++ b/tests/browser/animations.mjs
@@ -57,7 +57,7 @@ try {
   );
   console.log(`PASS ${browserName}: live motion preferences, responsive particle counts, page hide/show`);
 
-  await page.goto(new URL("/volume/3/ansi-ink-phile/", baseUrl).href);
+  await page.goto(new URL("/volume/1/rce-sapido_rb-1732/", baseUrl).href);
   await page.locator(".life-grid").waitFor();
   await settleTextLayout(page);
   const readLifeOffset = () =>

--- a/tests/browser/article-art.mjs
+++ b/tests/browser/article-art.mjs
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import sharp from "sharp";
+import { baseUrl, browserName, launchBrowser, settleTextLayout, stubExternalResources } from "./support.mjs";
+
+const samples = [
+  ["maze", "/volume/0/netgear-exs27-0/"],
+  ["sort", "/volume/1/cross-isas/"],
+  ["bits", "/volume/1/libxml2-cve-2017-9048/"],
+  ["asm", "/volume/1/blackhat-mea-ctf-final-2025/"],
+  ["reorder", "/volume/1/libtiff-cve-2016-9297/"]
+];
+const browser = await launchBrowser();
+const errors = [];
+const frame = (page) => page.locator("[data-algorithm-art]").evaluate((root) => root.innerHTML);
+const expectMotion = async (page, previous) => {
+  previous ??= await frame(page);
+  await page.waitForFunction((before) => document.querySelector("[data-algorithm-art]").innerHTML !== before, previous);
+};
+const expectFrozen = async (page) => {
+  await page.waitForTimeout(100);
+  const before = await frame(page);
+  await page.waitForTimeout(600);
+  assert.equal(await frame(page), before);
+  return before;
+};
+
+async function assertBarSpacing(page) {
+  const svg = page.locator("[data-algorithm-art] svg");
+  const width = await svg.evaluate((element) => element.getBoundingClientRect().width * devicePixelRatio);
+  const { data, info } = await sharp(await svg.screenshot())
+    .removeAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  // Sample the common baseline inside the overlaid Gohu border.
+  const border = Math.max(2, Math.ceil((2 * width) / 184));
+  const y = info.height - Math.max(4, border + 1);
+  const row = [];
+  for (let x = border; x < info.width - border; x += 1) {
+    const offset = (y * info.width + x) * info.channels;
+    const filled = Math.max(data[offset], data[offset + 1], data[offset + 2]) > 50;
+    if (row.at(-1)?.filled === filled) row.at(-1).length += 1;
+    else row.push({ filled, length: 1 });
+  }
+  const gaps = row
+    .slice(1, -1)
+    .filter((run) => !run.filled)
+    .map((run) => run.length);
+  assert.equal(gaps.length, 13, "All 14 bars stay separated");
+  assert.deepEqual(
+    new Set(gaps),
+    new Set([Math.max(1, Math.round((2 * width) / 184))]),
+    "All rendered gaps have identical pixel widths"
+  );
+}
+
+async function assertBitAlignment(page) {
+  const offsets = await page.locator("[data-algorithm-art]").evaluate((root) => {
+    const labels = [...root.querySelectorAll(".algorithm-label")];
+    const digits = labels.filter((label) => /^[0-7]$/.test(label.textContent));
+    const cells = labels.filter((label) => /^[█░]{2}$/.test(label.textContent));
+    const top = cells[0].getBoundingClientRect().top;
+    const row = cells.filter((cell) => Math.abs(cell.getBoundingClientRect().top - top) < 0.1);
+    const center = (node) => {
+      const rect = node.getBoundingClientRect();
+      return rect.left + rect.width / 2;
+    };
+    return digits.map((digit, index) => center(digit) - center(row[index]));
+  });
+  assert.equal(offsets.length, 8);
+  assert.ok(
+    offsets.every((offset) => Math.abs(offset) < 0.1),
+    "Bit numbers remain centered under their cells"
+  );
+}
+
+try {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  await stubExternalResources(context);
+  const page = await context.newPage();
+  page.setDefaultTimeout(15000);
+  page.on("pageerror", (error) => errors.push(error.message));
+  for (const [kind, path] of samples) {
+    await page.goto(new URL(path, baseUrl).href);
+    await page.locator(".ascii-particles span").first().waitFor({ state: "attached" });
+    await settleTextLayout(page);
+    assert.equal(await page.locator("[data-algorithm-art]").getAttribute("data-algorithm-art"), kind);
+    assert.equal(await page.locator("[data-algorithm-art]").getAttribute("aria-hidden"), "true");
+    await expectMotion(page);
+    for (const width of [320, 390, 760, 1280]) {
+      await page.setViewportSize({ width, height: 844 });
+      await settleTextLayout(page);
+      const layout = await page.locator("[data-algorithm-art]").evaluate((root) => {
+        const art = root.getBoundingClientRect();
+        const svg = root.querySelector("svg");
+        const surface = (svg ?? root.querySelector("[data-algorithm-labels]")).getBoundingClientRect();
+        const inset = svg ? 0.5 : 1;
+        const glyphs = root.querySelector("[data-life-line]").getBoundingClientRect();
+        const cell = glyphs.width / 25;
+        const line = art.height / 17;
+        const styles = getComputedStyle(root.querySelector("pre"));
+        const body = document.querySelector(".phile-body-pre").getBoundingClientRect();
+        return {
+          overflow: document.documentElement.scrollWidth - innerWidth,
+          right: art.right,
+          bottom: art.bottom,
+          bodyTop: body.top,
+          offsets: [surface.left - art.left - cell * inset, surface.top - art.top - line * inset],
+          sizes: [surface.width - cell * (25 - inset * 2), surface.height - line * (17 - inset * 2)],
+          font: styles.fontFamily,
+          bodyFont: getComputedStyle(document.querySelector(".phile-body-pre")).fontFamily
+        };
+      });
+      assert.ok(layout.overflow <= 1 && layout.right <= width + 1, `${kind}: fits ${width}px`);
+      assert.ok(layout.bottom <= layout.bodyTop, `${kind}: stays clear of article content`);
+      assert.ok(
+        [...layout.offsets, ...layout.sizes].every((value) => Math.abs(value) < 1),
+        `${kind}: fills the Gohu frame at ${width}px`
+      );
+      assert.equal(layout.font, layout.bodyFont);
+      const textLayout = await page.locator("[data-algorithm-art]").evaluate((root) => {
+        const labels = [...root.querySelectorAll(".algorithm-label")].filter((label) => label.textContent);
+        if (!labels.length) return null;
+        const art = root.getBoundingClientRect();
+        const body = getComputedStyle(document.querySelector(".phile-body-pre"));
+        return {
+          fits: labels.every((label) => {
+            const bounds = label.getBoundingClientRect();
+            return (
+              bounds.left >= art.left &&
+              bounds.right <= art.right &&
+              bounds.top >= art.top &&
+              bounds.bottom <= art.bottom
+            );
+          }),
+          nativeFont: labels.every((label) => {
+            const style = getComputedStyle(label);
+            return style.fontFamily === body.fontFamily && style.fontSize === body.fontSize;
+          })
+        };
+      });
+      if (["bits", "asm", "reorder"].includes(kind)) {
+        assert.deepEqual(textLayout, { fits: true, nativeFont: true }, `${kind}: native Gohu text fits at ${width}px`);
+      }
+      if (kind === "sort") await assertBarSpacing(page);
+      if (kind === "bits") await assertBitAlignment(page);
+    }
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    const reduced = await expectFrozen(page);
+    await page.emulateMedia({ reducedMotion: "no-preference" });
+    await expectMotion(page, reduced);
+    await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+    const hidden = await expectFrozen(page);
+    await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true })));
+    await expectMotion(page, hidden);
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+    await page.waitForFunction(() => document.querySelector("[data-algorithm-art]").getBoundingClientRect().bottom < 0);
+    const offscreen = await expectFrozen(page);
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await expectMotion(page, offscreen);
+    console.log(
+      `PASS ${browserName}: ${kind} frame fill, desktop/mobile/desktop, reduced motion, page lifecycle, offscreen pause`
+    );
+  }
+
+  const staticContext = await browser.newContext({ javaScriptEnabled: false, viewport: { width: 390, height: 844 } });
+  await stubExternalResources(staticContext);
+  const staticPage = await staticContext.newPage();
+  for (const [kind, path] of samples) {
+    await staticPage.goto(new URL(path, baseUrl).href);
+    assert.equal(await staticPage.locator("[data-algorithm-art]").getAttribute("data-algorithm-art"), kind);
+    assert.ok((await frame(staticPage)).length > 50, `${kind}: useful artwork without JavaScript`);
+    assert.ok(await staticPage.locator(".phile-body-pre").first().isVisible());
+  }
+
+  const stillContext = await browser.newContext({ reducedMotion: "reduce" });
+  await stubExternalResources(stillContext);
+  const stillPage = await stillContext.newPage();
+  await stillPage.goto(new URL(samples[0][1], baseUrl).href);
+  const initial = await expectFrozen(stillPage);
+  assert.ok(initial.length > 50);
+  await stillPage.emulateMedia({ reducedMotion: "no-preference" });
+  await expectMotion(stillPage, initial);
+
+  const phoneContext = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 3,
+    reducedMotion: "reduce"
+  });
+  await stubExternalResources(phoneContext);
+  const phonePage = await phoneContext.newPage();
+  for (const [kind, path] of samples.filter(([kind]) => kind === "sort" || kind === "bits")) {
+    await phonePage.goto(new URL(path, baseUrl).href);
+    await settleTextLayout(phonePage);
+    if (kind === "sort") await assertBarSpacing(phonePage);
+    else await assertBitAlignment(phonePage);
+  }
+  console.log(`PASS ${browserName}: uniform bar gaps and centered bit numbers at desktop and phone pixel densities`);
+
+  const bitPath = samples.find(([kind]) => kind === "bits")[1];
+  const bitUrl = new URL(bitPath, baseUrl).href;
+  for (const speed of [1, 2]) {
+    await page.route(bitUrl, async (route) => {
+      const response = await route.fetch();
+      await route.fulfill({
+        response,
+        body: (await response.text()).replace(/data-speed="1"/, `data-speed="${speed}"`)
+      });
+    });
+    await page.goto(bitUrl);
+    await page.locator(".ascii-particles span").first().waitFor({ state: "attached" });
+    const clock = () =>
+      page
+        .locator(".algorithm-label")
+        .filter({ hasText: /^T [0-9A-F]{4}$/ })
+        .textContent();
+    const before = Number.parseInt((await clock()).slice(2), 16);
+    await page.waitForTimeout(1500);
+    const steps = (Number.parseInt((await clock()).slice(2), 16) - before + 65536) % 65536;
+    assert.ok(Math.abs(steps - 3 * speed) <= 1, `Byte steps follow ${speed}x speed: ${steps} steps`);
+    await page.unroute(bitUrl);
+  }
+  console.log(`PASS ${browserName}: discrete playback cadence and speed multiplier`);
+
+  // Exercise static configuration without mutating files or starting a second server.
+  await context.route(new URL(samples[0][1], baseUrl).href, async (route) => {
+    const response = await route.fetch();
+    await route.fulfill({ response, body: (await response.text()).replace(/data-animated="true"/, "") });
+  });
+  await page.goto(new URL(samples[0][1], baseUrl).href);
+  await page.locator(".ascii-particles span").first().waitFor({ state: "attached" });
+  assert.equal(await page.locator("[data-algorithm-art][data-animated]").count(), 0);
+  await expectFrozen(page);
+  assert.deepEqual(errors, [], "Browser exceptions");
+  console.log(`PASS ${browserName}: static config, initial reduced motion, and no-JavaScript artwork`);
+} finally {
+  await browser.close();
+}

--- a/tests/browser/run.mjs
+++ b/tests/browser/run.mjs
@@ -1,5 +1,6 @@
 await import("./textmode-fit.mjs");
 await import("./animations.mjs");
+await import("./article-art.mjs");
 await import("./volume-decorations.mjs");
 await import("./volume-rendering.mjs");
 await import("./particle-activity.mjs");

--- a/tests/configuration/config.test.ts
+++ b/tests/configuration/config.test.ts
@@ -4,6 +4,7 @@ import { defaultAppearance, defaultEffects } from "../../src/config/defaults";
 import { resolveConfig, resolveVolumeConfig } from "../../src/config/resolve";
 import type { CveCircuitConfig, EntropicConfig } from "../../src/config/types";
 import { sitemapEntries } from "../../src/features/seo/xml";
+import { defaultAlgorithmOptions } from "../../src/shared/textmode/algorithm-art/model";
 
 const site = { url: "https://example.org/", name: "My Philes", description: "A personal textmode site" };
 
@@ -175,16 +176,53 @@ test("WKD can be disabled without deleting its email or public key path", () => 
 });
 
 test("article tools default to enabled and can be disabled independently", () => {
-  assert.deepEqual(resolveConfig({ site }).philes, { inspect: true, fragmentLinks: true });
-  assert.deepEqual(resolveConfig({ site, philes: { inspect: false } }).philes, { inspect: false, fragmentLinks: true });
+  const decoration = defaultAlgorithmOptions;
+  assert.deepEqual(resolveConfig({ site }).philes, { inspect: true, fragmentLinks: true, decoration });
+  assert.deepEqual(resolveConfig({ site, philes: { inspect: false } }).philes, {
+    inspect: false,
+    fragmentLinks: true,
+    decoration
+  });
   assert.deepEqual(resolveConfig({ site, philes: { fragmentLinks: false } }).philes, {
     inspect: true,
-    fragmentLinks: false
+    fragmentLinks: false,
+    decoration
   });
   // @ts-expect-error Check the runtime boundary for JavaScript configuration too.
   assert.throws(() => resolveConfig({ site, philes: { inspect: "false" } }), /philes.inspect/);
   // @ts-expect-error Check the runtime boundary for JavaScript configuration too.
   assert.throws(() => resolveConfig({ site, philes: { fragmentLinks: "false" } }), /philes.fragmentLinks/);
+});
+
+test("article artwork supports pool selection, static playback, speed, and a global off switch", () => {
+  const resolve = (decoration?: NonNullable<EntropicConfig["philes"]>["decoration"]) =>
+    resolveConfig({ site, philes: { decoration } }).philes.decoration;
+  assert.deepEqual(resolve(), defaultAlgorithmOptions);
+  assert.deepEqual(resolve({ effects: undefined, animated: undefined, speed: undefined }), defaultAlgorithmOptions);
+  assert.deepEqual(resolve({ effects: ["maze"], animated: false, speed: 0.5 }), {
+    effects: ["maze"],
+    animated: false,
+    speed: 0.5
+  });
+  assert.equal(resolve(false), false);
+  for (const invalid of [
+    null,
+    true,
+    "maze",
+    [],
+    { effects: [] },
+    { effects: ["maze", "maze"] },
+    { effects: ["unknown"] },
+    { effects: "life" },
+    { animated: "false" },
+    { speed: "1" },
+    { speed: 0 },
+    { speed: 4.1 },
+    { speed: Number.NaN }
+  ]) {
+    // @ts-expect-error Exercise JavaScript configuration values at the runtime boundary.
+    assert.throws(() => resolve(invalid), /philes.decoration/);
+  }
 });
 
 test("a minimal configuration creates a new site without inheriting the theme author's links or records", () => {

--- a/tests/content/render.test.ts
+++ b/tests/content/render.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { Phile } from "../../src/features/philes";
 import { parsePhile } from "../../src/features/philes/content/frontmatter";
+import { phileSchema } from "../../src/features/philes/content/schema";
 import { routeForPhile } from "../../src/features/philes/data/routing";
 import { renderPhile } from "../../src/features/philes/rendering";
+import { algorithmKinds } from "../../src/shared/textmode/algorithm-art/model";
 
 function phile(body: string, redacted = false): Phile {
   const entry = {
@@ -19,6 +21,18 @@ test("frontmatter accepts BOM, CRLF, and a closing delimiter at EOF", () => {
   const result = parsePhile('\uFEFF---\r\ntitle: Example\r\n"redacted": TRUE\r\n---');
   assert.equal(result.data.redacted, true);
   assert.equal(result.body, "");
+});
+
+test("frontmatter can pin any article algorithm or remove the artwork and its reserved space", () => {
+  const article = phile("Readable body");
+  for (const decoration of [...algorithmKinds, false] as const) {
+    const data = phileSchema.parse({ ...article.data, decoration });
+    const result = renderPhile({ ...article, data });
+    assert.equal(result.header.decoration, decoration);
+    assert.equal(result.header.lineCount, decoration === false ? 0 : 17);
+    assert.equal(result.body.kind, "content");
+  }
+  assert.equal(phileSchema.safeParse({ ...article.data, decoration: "missing" }).success, false);
 });
 
 test("the rendering interface never includes redacted source or media", () => {

--- a/tests/textmode/algorithm-art.test.ts
+++ b/tests/textmode/algorithm-art.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { type AlgorithmFrame, createAlgorithm, renderBars } from "../../src/shared/textmode/algorithm-art/engine";
+import { algorithmKinds, selectAlgorithm } from "../../src/shared/textmode/algorithm-art/model";
+
+test("article assignment is stable, independent of pool order, and only changes to added candidates", () => {
+  const pool = ["life", "maze"] as const;
+  const selected = new Set<string>();
+  for (let index = 0; index < 200; index += 1) {
+    const key = `/volume/1/article-${index}/`;
+    const before = selectAlgorithm(key, pool);
+    assert.equal(selectAlgorithm(key, [...pool].reverse()), before);
+    const after = selectAlgorithm(key, algorithmKinds);
+    assert.ok(after === before || !pool.some((kind) => kind === after));
+    selected.add(after);
+  }
+  assert.deepEqual(selected, new Set(algorithmKinds));
+  assert.equal(selectAlgorithm("any article", ["maze"]), "maze");
+  assert.throws(() => selectAlgorithm("any article", []), RangeError);
+});
+
+function rectangles(path: string) {
+  return [...path.matchAll(/M(\d+) (\d+)h(\d+)v(\d+)h-\d+z/g)].map((match) => ({
+    x: Number(match[1]),
+    y: Number(match[2]),
+    width: Number(match[3]),
+    height: Number(match[4])
+  }));
+}
+
+function visibleShapes(frame: AlgorithmFrame, progress = 0) {
+  const field = rectangles(frame.ink + frame.accent + (frame.trail ?? ""));
+  const moving = (frame.motion ?? []).map((shape) => ({
+    ...shape,
+    x: shape.fromX + (shape.x - shape.fromX) * progress,
+    y: shape.fromY + (shape.y - shape.fromY) * progress
+  }));
+  return [...field, ...moving]
+    .map((shape) => ({
+      x: Math.max(0, shape.x),
+      y: Math.max(0, shape.y),
+      width: Math.min(184, shape.x + shape.width) - Math.max(0, shape.x),
+      height: Math.min(210, shape.y + shape.height) - Math.max(0, shape.y)
+    }))
+    .filter((shape) => shape.width > 0 && shape.height > 0);
+}
+
+test("new algorithms stay bounded and use all four edges throughout multiple cycles", () => {
+  for (const kind of ["maze", "sort"] as const) {
+    const first = createAlgorithm(kind, "example");
+    const second = createAlgorithm(kind, "example");
+    const distinct = new Set<string>();
+    for (let tick = 0; tick < 450; tick += 1) {
+      const frame = first.next();
+      assert.deepEqual(frame, second.next(), `${kind}: static and browser playback agree`);
+      distinct.add(frame.ink);
+      const shapes = visibleShapes(frame, 1);
+      assert.ok(shapes.length > 0, `${kind}: never presents an empty frame`);
+      for (const { x, y, width, height } of shapes) {
+        assert.ok(x >= 0 && y >= 0 && width > 0 && height > 0 && x + width <= 184 && y + height <= 210);
+      }
+      assert.equal(Math.min(...shapes.map(({ x }) => x)), 0, `${kind}: no left padding`);
+      assert.equal(Math.min(...shapes.map(({ y }) => y)), 0, `${kind}: no top padding`);
+      assert.equal(Math.max(...shapes.map(({ x, width }) => x + width)), 184, `${kind}: no right padding`);
+      assert.equal(Math.max(...shapes.map(({ y, height }) => y + height)), 210, `${kind}: no bottom padding`);
+    }
+    assert.ok(distinct.size > 30, `${kind}: keeps evolving`);
+  }
+});
+
+test("sorting preserves all bars, reaches ascending order, and starts a fresh permutation", () => {
+  const animation = createAlgorithm("sort", "example");
+  const ascending = Array.from({ length: 14 }, (_, index) => (index + 1) * 15);
+  let sorted = false;
+  let restarted = false;
+  for (let tick = 0; tick < 250; tick += 1) {
+    const frame = animation.next();
+    const values = rectangles(frame.ink + frame.accent)
+      .sort((a, b) => a.x - b.x)
+      .map(({ height }) => height);
+    assert.deepEqual(
+      [...values].sort((a, b) => a - b),
+      ascending
+    );
+    const ordered = values.every((value, index) => value === ascending[index]);
+    if (sorted && !ordered) restarted = true;
+    sorted ||= ordered;
+  }
+  assert.ok(sorted && restarted);
+});
+
+test("sorting keeps identical gaps and fills the available width at different pixel densities", () => {
+  const values = Array.from({ length: 14 }, (_, index) => 14 - index);
+  for (const width of [90, 96, 168, 192, 288, 336, 576]) {
+    for (const gap of [1, 2, 3]) {
+      const frame = renderBars(values, 4, width, 224, gap);
+      const bars = rectangles(frame.ink + frame.accent).sort((a, b) => a.x - b.x);
+      assert.equal(bars.length, values.length);
+      assert.equal(bars[0]?.x, 0);
+      assert.equal((bars.at(-1)?.x ?? 0) + (bars.at(-1)?.width ?? 0), width);
+      assert.ok(Math.max(...bars.map((bar) => bar.width)) - Math.min(...bars.map((bar) => bar.width)) <= 1);
+      for (let index = 1; index < bars.length; index += 1) {
+        assert.equal((bars[index]?.x ?? 0) - ((bars[index - 1]?.x ?? 0) + (bars[index - 1]?.width ?? 0)), gap);
+      }
+    }
+  }
+});
+
+test("a completed maze has one connected, acyclic passage network", () => {
+  const animation = createAlgorithm("maze", "example");
+  let frame = animation.next();
+  for (let tick = 0; frame.motion?.length && tick < 400; tick += 1) frame = animation.next();
+  assert.equal(frame.motion?.length, 0, "The maze completes within one traversal");
+  const walls = rectangles(frame.ink);
+  const adjacency = Array.from({ length: 195 }, () => [] as number[]);
+  let openings = 0;
+  for (let row = 0; row < 15; row += 1) {
+    for (let column = 0; column < 13; column += 1) {
+      const cell = row * 13 + column;
+      for (const [neighbor, x, y] of [
+        ...(column < 12 ? [[cell + 1, Math.round(((column + 1) * 184) / 13), row * 14 + 7]] : []),
+        ...(row < 14 ? [[cell + 13, Math.round((column * 184) / 13) + 7, (row + 1) * 14]] : [])
+      ]) {
+        if (neighbor === undefined || x === undefined || y === undefined) throw new Error("Missing maze edge");
+        if (walls.some((wall) => x >= wall.x && x < wall.x + wall.width && y >= wall.y && y < wall.y + wall.height))
+          continue;
+        adjacency[cell]?.push(neighbor);
+        adjacency[neighbor]?.push(cell);
+        openings += 1;
+      }
+    }
+  }
+  const seen = new Set<number>();
+  const stack = [0];
+  while (stack.length) {
+    const cell = stack.pop() ?? 0;
+    if (seen.has(cell)) continue;
+    seen.add(cell);
+    stack.push(...(adjacency[cell] ?? []));
+  }
+  assert.equal(seen.size, 195);
+  assert.equal(openings, 194);
+});
+
+test("the maze cursor follows open neighboring passages during exploration and backtracking", () => {
+  const animation = createAlgorithm("maze", "example");
+  for (let tick = 0; tick < 800; tick += 1) {
+    const frame = animation.next();
+    const walls = rectangles(frame.ink);
+    for (const cursor of frame.motion ?? []) {
+      const distance = Math.abs(cursor.x - cursor.fromX) + Math.abs(cursor.y - cursor.fromY);
+      assert.ok(distance <= 15, "No cursor teleport across several cells");
+      assert.ok(cursor.x === cursor.fromX || cursor.y === cursor.fromY, "Follow one corridor");
+      for (const progress of [0, 0.25, 0.5, 0.75, 1]) {
+        const x = cursor.fromX + (cursor.x - cursor.fromX) * progress + cursor.width / 2;
+        const y = cursor.fromY + (cursor.y - cursor.fromY) * progress + cursor.height / 2;
+        assert.equal(
+          walls.some((wall) => x >= wall.x && x < wall.x + wall.width && y >= wall.y && y < wall.y + wall.height),
+          false
+        );
+      }
+    }
+  }
+});
+
+test("maze renewal rebuilds one row at a time instead of flashing a whole new grid", () => {
+  const animation = createAlgorithm("maze", "example");
+  let previous = new Set<string>();
+  let renewals = 0;
+  for (let tick = 0; tick < 450; tick += 1) {
+    const frame = animation.next();
+    const current = new Set(rectangles(frame.ink).map((wall) => JSON.stringify(wall)));
+    if (previous.size) {
+      const added = [...current].filter((wall) => !previous.has(wall));
+      assert.ok(added.length <= 26, "At most one row is restored per step");
+      if (added.length) renewals += 1;
+    }
+    previous = current;
+  }
+  assert.ok(renewals > 1);
+});

--- a/tests/textmode/processors.test.ts
+++ b/tests/textmode/processors.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createAlgorithm } from "../../src/shared/textmode/algorithm-art/engine";
+import {
+  applyBitOperation,
+  createByteMachine,
+  createReorderQueue
+} from "../../src/shared/textmode/algorithm-art/processors";
+
+test("byte operations rotate across the high bit, preserve eight bits, and shift in zeroes", () => {
+  assert.equal(applyBitOperation(0xa5, "XOR", 0x5a), 0xff);
+  assert.equal(applyBitOperation(0x81, "ROL", 1), 0x03);
+  assert.equal(applyBitOperation(0x81, "ROL", 7), 0xc0);
+  assert.equal(applyBitOperation(0x81, "ROL", 0), 0x81);
+  assert.equal(applyBitOperation(0xe5, "SHR", 2), 0x39);
+  assert.equal(applyBitOperation(1, "SHR", 1), 0);
+});
+
+test("the assembly loop updates registers, takes branches, then copies its completed result", () => {
+  const machine = createByteMachine(() => 0);
+  const execution = [0, 1, 2, 3, 4, 5, 6, 2, 3, 4, 5, 6, 2, 3, 4, 5, 6, 7, 8];
+  const sums = [];
+  for (const pc of execution) {
+    const state = machine.next();
+    assert.equal(state.executed, pc);
+    assert.ok(state.registers.every((value) => value >= 0 && value <= 255));
+    if (pc === 4) sums.push(state.registers[2]);
+    if (pc === 6) assert.equal(state.nextPc, state.zero ? 7 : 2);
+    if (pc === 8) {
+      assert.equal(state.nextPc, 0);
+      assert.deepEqual(state.registers, [14, 0, 22, 22]);
+    }
+  }
+  assert.deepEqual(sums, [2, 8, 22]);
+  assert.equal(machine.next().executed, 0);
+});
+
+test("out-of-order execution observes dependencies and retires only a contiguous prefix", () => {
+  const queue = createReorderQueue(() => 0);
+  let outOfOrder = false;
+  let completed = false;
+  let restarted = false;
+  for (let tick = 0; tick < 120; tick += 1) {
+    const state = queue.next();
+    assert.ok(state.entries.filter((entry) => entry.status === "running").length <= 2);
+    assert.equal(state.entries.length, 6);
+    for (const [index, entry] of state.entries.entries()) {
+      assert.equal(entry.status === "retired", index < state.retired);
+      if (["running", "ready", "retired"].includes(entry.status)) {
+        for (const dependency of entry.dependencies) {
+          assert.ok(["ready", "retired"].includes(state.entries[dependency]?.status ?? ""));
+        }
+      }
+    }
+    outOfOrder ||= state.entries[1]?.status === "ready" && state.entries[0]?.status === "running";
+    if (completed && state.tick === 0) restarted = true;
+    completed ||= state.retired === 6;
+  }
+  assert.ok(outOfOrder && completed && restarted);
+});
+
+test("processor illustrations stay deterministic and use the full native character area", () => {
+  for (const kind of ["bits", "asm", "reorder"] as const) {
+    const a = createAlgorithm(kind, "article");
+    const b = createAlgorithm(kind, "article");
+    const distinct = new Set<string>();
+    for (let step = 0; step < 250; step += 1) {
+      const frame = a.next();
+      assert.deepEqual(frame, b.next(), "Static HTML and browser start with the same state");
+      const labels = frame.labels?.filter((label) => label.text) ?? [];
+      distinct.add(JSON.stringify(labels));
+      assert.ok(labels.length >= 15);
+      assert.equal(Math.min(...labels.map((label) => label.column)), 0);
+      assert.equal(Math.min(...labels.map((label) => label.row)), 0);
+      assert.equal(Math.max(...labels.map((label) => label.row)), 14);
+      assert.equal(Math.max(...labels.map((label) => label.column + label.text.length)), 23);
+      for (const label of labels) {
+        assert.ok(label.column >= 0 && label.row >= 0 && label.row <= 14);
+        assert.ok(label.column + label.text.length <= 23, `${kind}: text stays inside the frame`);
+        assert.doesNotMatch(label.text, /[\n\r\t]/);
+      }
+    }
+    assert.ok(distinct.size > 30, `${kind}: keeps executing`);
+  }
+});


### PR DESCRIPTION
## Summary

Article headers previously repeated Life on every page. Choose a stable effect from each article URL, adding maze carving, insertion sort, bit registers, a small assembly loop, and out-of-order execution while retaining the original Life renderer.

Configure the candidate pool, speed, static playback, or a global off switch through `philes.decoration`; frontmatter can pin or hide an individual article's artwork. The new effects use the existing Gohu frame and theme colors, keep bar gaps and bit labels aligned at mobile pixel densities, and pause offscreen or for reduced motion. Discrete effects update only at algorithm steps; maze cursors interpolate between steps.

## Scope

- [x] User-facing behavior
- [ ] Content
- [x] Documentation
- [ ] Tooling or automation
- [ ] Build, CI, or deployment
- [x] Performance or maintenance

## Verification

- `pnpm test`: 98 passing tests, including deterministic assignment, algorithm invariants, configuration, and frontmatter overrides.
- `pnpm lint` and `pnpm build` (including `pnpm check`): passed in a clean validation checkout.
- Chromium and Firefox: desktop/mobile layout, pixel spacing, bit-label centering, 1x/2x playback, reduced motion, page lifecycle and offscreen pauses, static configuration, and no-JavaScript artwork.

## Notes

Life retains its original renderer and timing; the new playback controls apply to the added effects.
